### PR TITLE
Add LICENSE file to the installed kit (/opt/omi)

### DIFF
--- a/Unix/installbuilder/datafiles/Base_OMI.data
+++ b/Unix/installbuilder/datafiles/Base_OMI.data
@@ -19,6 +19,7 @@ PAM_CONF_FILE: '/etc/pam.conf'
 PAM_CONF_DIR: '/etc/pam.d'
 
 %Files
+/opt/omi/LICENSE;                             ../../LICENSE;                         644; root; ${{ROOT_GROUP_NAME}}
 /opt/omi/bin/omiagent;                        bin/omiagent;                          755; root; ${{ROOT_GROUP_NAME}}
 /opt/omi/bin/omiserver;                       bin/omiserver;                         755; root; ${{ROOT_GROUP_NAME}}
 /opt/omi/bin/omicli;                          bin/omicli;                            755; root; ${{ROOT_GROUP_NAME}}


### PR DESCRIPTION
@Microsoft/ostc-devs 

Tested, this puts a new LICENSE file in /opt/omi, as requested by @KrisBash.
