### PR TITLE
Disable Travis on MAC OS/X until build issue is resolved

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ matrix:
     - os: osx
       osx_image: xcode7.3
 
+  allow_failures:
+    - os: osx
+
 addons:
   apt:
     packages:


### PR DESCRIPTION
Travis builds show as failing due to openssl issues on Mac OS/X.

Disable Mac OS/X builds until the situation is resolved.

@Microsoft/ostc-devs 
@Microsoft/omi-devs 