### PR TITLE
Fix OpenSSL linking on MacOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ matrix:
     - os: osx
       osx_image: xcode7.3
 
-  allow_failures:
-    - os: osx
-
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,6 @@ addons:
       - time
 
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew install openssl && brew link --force openssl ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew install openssl ; fi
 
 script: cd Unix && ./regress

--- a/Unix/configure
+++ b/Unix/configure
@@ -1210,16 +1210,67 @@ if [ -z "$openssl" ]; then
 
 fi
 
-if [ "$opensslcflags_found" != "1" ]; then
-    opensslcflags=`$pkgconfig --cflags openssl`
-fi
+if [ "$os" == "DARWIN" ]; then
 
-if [ -z "$openssllibs_found" ]; then
-    openssllibs=`$pkgconfig --libs openssl`
-fi
+    # if no OpenSSL flags were passed and we cannot set it to use Homebrew's OpenSSL,
+    # configure should exit as OMI cannot be built with OS X's defaults
+    if [ "$opensslcflags_found" != "1" ] &&
+           [ -z "$openssllibdir_found" ] &&
+           [ -z "$openssllibs_found" ]; then
+        opensslshouldexit=1
+    fi
 
-if [ -z "$openssllibdir_found" ]; then
-    openssllibdir=`$pkgconfig --variable=libdir openssl`
+    echo $echon "checking whether brew command is on the path... $echoc"
+
+    brew=`which brew`
+
+    if [ -x "$brew" ]; then
+        echo "yes"
+
+        echo $echon "checking whether Homebrew's OpenSSL package is installed... $echoc"
+
+        opensslprefix=`$brew --prefix openssl`
+
+        if [ -d "$opensslprefix" ]; then
+            echo "yes"
+
+            if [ "$opensslcflags_found" != "1" ]; then
+                opensslcflags="-I$opensslprefix/include"
+            fi
+
+            if [ -z "$openssllibdir_found" ]; then
+                openssllibdir="$opensslprefix/lib"
+            fi
+
+            if [ -z "$openssllibs_found" ]; then
+                openssllibs="-L$openssllibdir -lssl -lcrypto -lz"
+            fi
+        else
+            echo "no"
+
+            if [ "$opensslshouldexit" == 1 ]; then
+                exit 1
+            fi
+        fi
+    else
+        echo "no"
+
+        if [ "$opensslshouldexit" == 1 ]; then
+            exit 1
+        fi
+    fi
+else
+    if [ "$opensslcflags_found" != "1" ]; then
+        opensslcflags=`$pkgconfig --cflags openssl`
+    fi
+
+    if [ -z "$openssllibs_found" ]; then
+        openssllibs=`$pkgconfig --libs openssl`
+    fi
+
+    if [ -z "$openssllibdir_found" ]; then
+        openssllibdir=`$pkgconfig --variable=libdir openssl`
+    fi
 fi
 
 ##==============================================================================


### PR DESCRIPTION
Resolves #63.

See commit messages.

@jeffaco I kind of had to guess at the right way to slip this information into OMI's build system (there docs anywhere on how to do this right?). As it is, it works. But I'm afraid `./install` will fail because `buildtool` isn't updated. However, I didn't update `buildtool` because it seems like duplicated logic. `configure` does not use `buildtool` to setup OpenSSL flags, except when it generates `install`; it makes no sense!

Note that if the user of `configure` did not pass any OpenSSL flags at all, and Homebrew's OpenSSL was not found, `configure` exits with 1 as the default "OpenSSL" library (it's not OpenSSL) on OS X does not work with OMI.