### PR TITLE
Fix builds on Solaris 10 platforms

### DIFF
--- a/Unix/configure
+++ b/Unix/configure
@@ -1210,7 +1210,7 @@ if [ -z "$openssl" ]; then
 
 fi
 
-if [ "$os" == "DARWIN" ]; then
+if [ "$os" = "DARWIN" ]; then
 
     # if no OpenSSL flags were passed and we cannot set it to use Homebrew's OpenSSL,
     # configure should exit as OMI cannot be built with OS X's defaults


### PR DESCRIPTION
Prior OS/X changes for SSL broke the Solaris builds

@Microsoft/ostc-devs 
@andschwa 

PBUILD running successfully, at least for the hosts that are up right now (including Solaris 10 x86, which was previously broken).