### PR TITLE
Removes heavy usage of /tmp file system in regress

### DIFF
--- a/Unix/build.mak
+++ b/Unix/build.mak
@@ -8,6 +8,10 @@ ifndef OUTPUTDIR
 $(error OUTPUTDIR is undefined)
 endif
 
+ifndef DISTBASE
+    DISTBASE=$(`pwd`/../tmp)
+endif
+
 include $(OUTPUTDIR)/config.mak
 
 TOP=.
@@ -340,7 +344,7 @@ endif
 ##
 ##==============================================================================
 
-DISTTMPDIR=/tmp/omi/$(USER)
+DISTTMPDIR=$(DISTBASE)/tmp/omi/$(USER)
 DIST=omi-$(CONFIG_VERSION)
 
 DISTTAR=$(CONFIGUREDIR)/$(DIST).tar
@@ -387,9 +391,10 @@ dist.zip: distcommon
 ##
 ##==============================================================================
 
-CHECKDIR=/tmp/omicheck.$(shell ./buildtool username)
+CHECKDIR=$(DISTBASE)/tmp/omicheck.$(shell ./buildtool username)
 
 check:
+	echo $(DISTBASE)
 	rm -rf $(CHECKDIR)
 	( cd $(CONFIGUREDIR); $(OUTPUTDIR)/install --destdir=$(CHECKDIR) )
 	( LD_LIBRARY_PATH=$(CHECKDIR)/$(CONFIG_LIBDIR);  \

--- a/Unix/configure
+++ b/Unix/configure
@@ -1806,6 +1806,8 @@ ldlibrarypath=`$buildtool ldlibrarypath $buildtoolopts`
 fn=$outputdir/install
 outputdirrelative=./$outputdirname
 
+echo "Copy install script into $fn"
+
 cat > $fn <<EOF
 #!/bin/sh
 ##==============================================================================
@@ -1814,6 +1816,7 @@ cat > $fn <<EOF
 ##
 ##==============================================================================
 
+set -x
 ##
 ## Check options
 ##
@@ -2071,8 +2074,9 @@ chmod 755 \$destdir/$bindir/omiuninstall
 ## Print success message!
 ##
 
-echo "Successfully installed under under: \$destdir/$prefix"
+echo "Successfully installed under: \$destdir/$prefix"
 
+set +x
 EOF
 
 chmod +x $fn

--- a/Unix/tests/http/test_http.cpp
+++ b/Unix/tests/http/test_http.cpp
@@ -43,7 +43,9 @@ NitsSetup(TestHttpSetup)
 {
     Sock_Start();
     PORT++;
+    IgnoreAuthCalls(1);
 }
+
 NitsEndSetup
 
 NitsCleanup(TestHttpSetup)


### PR DESCRIPTION
Currently build.mak copies then installs the build hierarchy into /tmp file system. That has been changed to omi/tmp.