### PR TITLE
Client-side timeout changes

### DIFF
--- a/Unix/wsman/wsmanclient.c
+++ b/Unix/wsman/wsmanclient.c
@@ -596,7 +596,7 @@ static void _WsmanClient_SendIn_IO_Thread(void *_self, Message* msg)
         DatetimeToUsec(&datetime, &usec);
 
         /* Add a bit to handle network timings to give server chance to finish */
-        usec += 5000;
+        usec += 10000000;
 
         HttpClient_SetTimeout(self->httpClient, usec);
     }


### PR DESCRIPTION
* Propagate timeout error if one happens from the client -- needs to be
  properly handled as it is sending an invalid MI_Result, but it is
  better than sending a success
* Make client socket timeout be a little more than the operation timeout
  sent to the server so server has time to send an actual response
This partially addresses #112 - client not reporting timeout error, although needs to send a proper error code going forwards, as well as full fix for #113 - client needs to wait a little longer than the server is given to respond.

@Microsoft/omi-devs @Microsoft/ostc-devs @yakman2020  @palladia