### PR TITLE
Power8 OMI name changes

### DIFF
--- a/Unix/installbuilder/GNUmakefile
+++ b/Unix/installbuilder/GNUmakefile
@@ -36,7 +36,11 @@ endif
 
 # New output format for OMI on Linux (avoids ugly renaming since we always build universal)
 ifeq ($(PF),Linux)
-OUTPUTFILE_LINE = --OUTPUTFILE=omi-$(CONFIG_VERSION)-$(CONFIG_PATCH_LEVEL).universal.$(PF_ARCH)
+  ifeq ($(PF_ARCH),ppc)
+    OUTPUTFILE_LINE = --OUTPUTFILE=omi-$(CONFIG_VERSION)-$(CONFIG_PATCH_LEVEL).rhel.$(PF_ARCH)
+  else
+    OUTPUTFILE_LINE = --OUTPUTFILE=omi-$(CONFIG_VERSION)-$(CONFIG_PATCH_LEVEL).universal.$(PF_ARCH)
+  endif
 endif
 
 # DSC output format (used by DSC installbuilder Makefile)


### PR DESCRIPTION
Changes: 
----------
GNUmakefile : Naming the OMI rpm file like "omi-1.1.0-0.rhel.ppc.rpm" because this is not Universal linux, hence naming so.
@ostcdevs @jeffaco