### PR TITLE
Add support for Jenkins builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # git ignore file for omi project
 
+/Packages
 /Unix/GNUmakefile
 /Unix/output
 /Unix/output1

--- a/Unix/configure
+++ b/Unix/configure
@@ -63,6 +63,22 @@ cimschema="CIM-2.32.0"
 
 ##==============================================================================
 ##
+## Set common options for Distributed Builds
+##
+##==============================================================================
+
+set_microsoft_build_options()
+{
+    enable_preexec=1
+    prefix=/opt/omi
+    localstatedir=/var/opt/omi
+    sysconfdir=/etc/opt/omi/conf
+    certsdir=/etc/opt/omi/ssl
+    enable_native_kits=1
+}
+
+##==============================================================================
+##
 ## Get command line options that start with slash.
 ##
 ##==============================================================================
@@ -260,12 +276,7 @@ do
         ;;
 
     --enable-microsoft)
-      enable_preexec=1
-      prefix=/opt/omi
-      localstatedir=/var/opt/omi
-      sysconfdir=/etc/opt/omi/conf
-      certsdir=/etc/opt/omi/ssl
-      enable_native_kits=1
+      set_microsoft_build_options
       ;;
 
     --enable-native-kits)
@@ -279,6 +290,15 @@ do
       fi
 
       enable_ulinux=1
+      ;;
+
+    --enable-system-build)
+      set_microsoft_build_options
+
+      # Enable universal linux (--enable-ulinux) if we're on Linux and not PPC
+      if  [ "`uname -s`" = "Linux" -a "`uname -m`" != "ppc64le" ]; then
+          enable_ulinux=1
+      fi
       ;;
 
     --disable-makefile-gen)
@@ -378,6 +398,8 @@ OPTIONS:
                             builds of OMI.
     --enable-native-kits    Build native kits for the current operating system.
     --enable-ulinux         Build universal SSL kits for all versions of Linux.
+    --enable-system-build   Build all build options as required for Microsoft
+                            builds of OMI, including ULINUX as necessary
     --disable-makefile-gen  Disable Makefile generation (used internally for
                             universal builds)
 

--- a/Unix/installbuilder/GNUmakefile
+++ b/Unix/installbuilder/GNUmakefile
@@ -14,8 +14,8 @@ include $(TOP)/config.mak
 #    omi/Packages/openssl_1.0.0 - good for binaries for OpenSSL 1.0.0
 #
 # This makes it easier for Jenkins to have a reasonable directory layout
-PACKAGE_DIR_PREFIX = $(shell echo $(OUTPUTDIRNAME) | sed 's/output//' | sed 's~^_open~/open~')
-PACKAGE_DIR = $(TOP)/../Packages$(PACKAGE_DIR_PREFIX)
+PACKAGE_DIR_SUFFIX = $(shell echo $(OUTPUTDIRNAME) | sed 's/output//' | sed 's~^_open~/open~')
+PACKAGE_DIR = $(TOP)/../Packages/$(BUILD_CONFIGURATION)$(PACKAGE_DIR_SUFFIX)
 
 DISTRO_TYPE = $(PF)
 ifeq ($(PF),Linux)

--- a/Unix/installbuilder/GNUmakefile
+++ b/Unix/installbuilder/GNUmakefile
@@ -2,6 +2,21 @@ TOP = $(shell cd .. ; pwd)
 include $(TOP)/../../pal/build/config.mak
 include $(TOP)/config.mak
 
+# $(OUTPUTDIRNAME) will be something like:
+#    output
+#    output_openssl_0.9.8
+#    output_openssl_1.0.0
+#
+# Get this into some reasonable prefix for the package directory.
+#
+#    omi/Packages - good for only one set of packages
+#    omi/Packages/openssl_0.9.8 - good for binaries for OpenSSL 0.9.8
+#    omi/Packages/openssl_1.0.0 - good for binaries for OpenSSL 1.0.0
+#
+# This makes it easier for Jenkins to have a reasonable directory layout
+PACKAGE_DIR_PREFIX = $(shell echo $(OUTPUTDIRNAME) | sed 's/output//' | sed 's~^_open~/open~')
+PACKAGE_DIR = $(TOP)/../Packages$(PACKAGE_DIR_PREFIX)
+
 DISTRO_TYPE = $(PF)
 ifeq ($(PF),Linux)
 DISTRO_TYPE = $(PF)_$(PF_DISTRO)
@@ -114,6 +129,9 @@ else
 		$(DATAFILES) Linux_DPKG.data
  endif
 endif
+
+	mkdir -p $(PACKAGE_DIR)
+	cp $(OUTPUTDIR)/release/omi-* $(PACKAGE_DIR)
 
 clean:
 #	sudo rm -rf $(OUTPUTDIR)/intermediate


### PR DESCRIPTION
. Modified configure script to support --enable-system-build
  (Makes it easy for Jenkins to just specify qualifier for all
  platforms, getting settings right regardless of platform)

. Modified package building to copy output files to a fixed
  directory path (makes it easy for Jenkins to publish to a
  good directory layout for build output).

@Microsoft/omi-devs @Microsoft/ostc-devs 