### PR TITLE
If building without --enable-debug, do not include debug symbols

### DIFF
--- a/Unix/buildtool
+++ b/Unix/buildtool
@@ -722,7 +722,7 @@ if [ "$arg1" = "cflags" -o "$arg1" = "cxxflags" ]; then
                 if test -n "$size_opt"; then
                     r="$r -Os"
                 else
-                    r="$r -g -O2"
+                    r="$r -O2"
                 fi
             fi
 


### PR DESCRIPTION
This allows for dramatically smaller disk image sizes

@Microsoft/omi-devs 