### PR TITLE
create version of libmi that has rpath=$ORIGIN

### DIFF
--- a/Unix/installbuilder/GNUmakefile
+++ b/Unix/installbuilder/GNUmakefile
@@ -142,9 +142,15 @@ else # ifneq ($(PF),Darwin)
 
 endif # ifneq ($(PF),Darwin)
 
-	# We also need a raw copy of libmi shared library
+	# We also need a raw copy of libmi shared library. If libmi_origin exists
+	# use that and rename it libmi.
 	mkdir -p $(PACKAGE_DIR)
+ifeq ($(shell test -e $(OUTPUTDIR)/lib/libmi_origin.* && echo -n yes),yes)
+	cp $(OUTPUTDIR)/lib/libmi_origin.* $(PACKAGE_DIR)
+	mv $(PACKAGE_DIR)/libmi_origin.* `echo $(PACKAGE_DIR)/libmi_origin.* | sed s/libmi_origin/libmi/`
+else
 	cp $(OUTPUTDIR)/lib/libmi.* $(PACKAGE_DIR)
+endif
 
 clean:
 #	sudo rm -rf $(OUTPUTDIR)/intermediate

--- a/Unix/midll/GNUmakefile
+++ b/Unix/midll/GNUmakefile
@@ -1,20 +1,18 @@
 TOP = ..
 include $(TOP)/config.mak
 
-CSHLIBRARY = mi
+GENERATE_ORIGIN=0
+ifeq ($(OS),LINUX)
+  GENERATE_ORIGIN=1
+endif
+ifeq ($(OS),DARWIN)
+  GENERATE_ORIGIN=1
+endif
 
-SOURCES = \
-	gnumain.c
+ifeq ($(GENERATE_ORIGIN),1)
+	DIRECTORIES = release origin
+else 
+	DIRECTORIES = release
+endif
 
-INCLUDES = $(TOP) $(TOP)/common
-
-DEFINES = MI_CONST= DETECT_FORBIDDEN_FUNCTIONS
-
-LIBRARIES = miapi protocol sock wql base $(PALLIBS) omi_error wsman http xmlserializer xml micodec mofparser
-
-EXPORTS=libmi.exp
-
-include $(TOP)/mak/rules.mak
-
-nm:
-	( nm -g $(TARGET)|grep -v U )
+include $(ROOT)/mak/rules.mak

--- a/Unix/midll/origin/GNUmakefile
+++ b/Unix/midll/origin/GNUmakefile
@@ -1,0 +1,22 @@
+TOP = ../..
+include $(TOP)/config.mak
+
+CSHLIBRARY = mi_origin
+
+SOURCES = \
+	../gnumain.c
+
+INCLUDES = $(TOP) $(TOP)/common
+
+DEFINES = MI_CONST= DETECT_FORBIDDEN_FUNCTIONS
+LIBRARIES = miapi protocol sock wql base $(PALLIBS) omi_error wsman http xmlserializer xml micodec mofparser
+
+EXPORTS=../libmi.exp
+
+include $(TOP)/mak/rules.mak
+
+# Setting this after rules as we are overriding the default one we use
+LIBPATHFLAGS = $(shell $(BUILDTOOL) libpath \'\$$ORIGIN\' )
+
+nm:
+	( nm -g $(TARGET)|grep -v U )

--- a/Unix/midll/release/GNUmakefile
+++ b/Unix/midll/release/GNUmakefile
@@ -1,0 +1,20 @@
+TOP = ../..
+include $(TOP)/config.mak
+
+CSHLIBRARY = mi
+
+SOURCES = \
+	../gnumain.c
+
+INCLUDES = $(TOP) $(TOP)/common
+
+DEFINES = MI_CONST= DETECT_FORBIDDEN_FUNCTIONS
+
+LIBRARIES = miapi protocol sock wql base $(PALLIBS) omi_error wsman http xmlserializer xml micodec mofparser
+
+EXPORTS=../libmi.exp
+
+include $(TOP)/mak/rules.mak
+
+nm:
+	( nm -g $(TARGET)|grep -v U )


### PR DESCRIPTION
... for mac and linux, then for installbuilder, copy that version to production server if it exists
@Microsoft/omi-devs 