### PR TITLE
Don't remove /opt on Linux

### DIFF
--- a/Unix/installbuilder/datafiles/Linux.data
+++ b/Unix/installbuilder/datafiles/Linux.data
@@ -188,7 +188,6 @@ if ${{PERFORMING_UPGRADE_NOT}}; then
     rm -f /opt/omi/lib/libcrypto* /opt/omi/lib/libssl* /opt/omi/lib/.libcrypto* /opt/omi/lib/.libssl*
     rmdir /opt/omi/lib > /dev/null 2>&1
     rmdir /opt/omi > /dev/null 2>&1
-    rmdir /opt > /dev/null 2>&1
 
     egrep -q "^omiusers:" /etc/group
     if [ $? -eq 0 ]; then


### PR DESCRIPTION
/opt is a system directory, not owned by omi

@Microsoft/ostc-devs 

