### PR TITLE
George/supported platforms

### DIFF
--- a/Unix/tests/cli/test_cli.cpp
+++ b/Unix/tests/cli/test_cli.cpp
@@ -139,6 +139,7 @@ bool ParseCommandLine(MI_Char command[PAL_MAX_PATH_SIZE], vector<MI_Char*>& args
 #pragma prefast (pop)
 #endif
 
+#if !defined(CONFIG_ENABLE_WCHAR)
 static bool SupportedPlatform()
 {
     if (0 == ntlmSupportedPlatform)
@@ -146,6 +147,7 @@ static bool SupportedPlatform()
 
     return (ntlmSupportedPlatform[0] == '1') ? true : false;
 }
+#endif
 
 static int StartServer()
 {
@@ -504,7 +506,7 @@ try_again:
 
 cleanup:
     // To allow pid file to be deleted
-    Sleep_Milliseconds(50);
+    Sleep_Milliseconds(100);
 
     return 0;
 }

--- a/Unix/tools/auth_tests_setup.sh
+++ b/Unix/tools/auth_tests_setup.sh
@@ -48,3 +48,46 @@ if [ "x${username}" != "x" -a "x${userpasswd}" != "x" ]; then
     NTLM_DOMAIN=$hostname
     export NTLM_DOMAIN
 fi
+
+#
+# As of 12/2016, PowerShell supports following linux platforms only
+# NTLM tests will run on these platforms only
+#
+# Ubuntu 14.04
+# Ubuntu 16.04
+# CentOS 7
+# MacOS 10.11
+
+supported=0
+
+kernel=`uname -s`
+if [ "$kernel" = "Darwin" ]; then
+    echo "Running on a MAC 10.11"
+    supported=1
+elif [ "$kernel" = "Linux" ]; then
+    if [ -f /etc/centos-release ]; then
+        fgrep "release 7" /etc/centos-release > /dev/null
+        if [ $? -eq 0 ]; then
+            echo "Running on CentOS 7"
+            supported=1
+        fi
+    elif [ -f /etc/lsb-release ]; then
+        fgrep "DISTRIB_RELEASE=14.04" /etc/lsb-release > /dev/null
+        if [ $? -eq 0 ]; then
+            echo "Running on Ubuntu 14.04"
+            supported=1
+        else
+            fgrep "DISTRIB_RELEASE=16.04" /etc/lsb-release > /dev/null
+            if [ $? -eq 0 ]; then
+                echo "Running on Ubuntu 16.04"
+                supported=1
+            fi
+        fi
+    else
+        echo "Running on Linux"
+        supported=1
+    fi
+fi
+
+export NTLM_SUPPORTED_PLATFORM
+NTLM_SUPPORTED_PLATFORM=$supported


### PR DESCRIPTION
1. Determine platform type so that NTLM tests only run on Mac/Linux platforms.
2. Stability modifications to make tests run more consistently.
