### PR TITLE
Adding extraHeaders to header string

### DIFF
--- a/Unix/http/httpclient.c
+++ b/Unix/http/httpclient.c
@@ -1809,6 +1809,15 @@ Page* _CreateHttpHeader(
     "Host: host\r\n"
 #endif
 
+    if (extraHeaders)
+    {
+        int i;
+        for (i = 0; i < extraHeaders->size; ++i)
+        {
+            pageSize += Strlen(extraHeaders->data[i]) + 2;
+        }
+    }
+
     /* calculate approximate page size */
     if (!verb)
         verb = "POST";
@@ -1860,14 +1869,27 @@ Page* _CreateHttpHeader(
     }
 
     if (authHeader)
-        {
+    {
         r = (int)Strlcpy(p, authHeader, pageSize);
         p += r;
         pageSize -= r;
         r = (int)Strlcpy(p,"\r\n", pageSize);
         p += r;
         pageSize -= r;
+    }
 
+    if (extraHeaders)
+    {
+        int i;
+        for (i = 0; i < extraHeaders->size; ++i)
+        {
+            r = (int)Strlcpy(p, extraHeaders->data[i], pageSize);
+            p += r;
+            pageSize -= r;
+            r = (int)Strlcpy(p,"\r\n", pageSize);
+            p += r;
+            pageSize -= r;
+        }
     }
 
     /* add trailing \r\n */


### PR DESCRIPTION
extraHeaders was previously ignored, and this now appends all extraHeaders onto the HTTP headers that are sent.

This fixes a bug associated with CM's NAA/NTLM.

@Microsoft/ostc-devs