### PR TITLE
compare op should be -gt not redirect to '5'

### DIFF
--- a/Unix/buildtool
+++ b/Unix/buildtool
@@ -788,7 +788,7 @@ if [ "$arg1" = "cflags" -o "$arg1" = "cxxflags" ]; then
 		        r="$r -D_DEFAULT_SOURCE"
 	        else
                 if test "$os" = "LINUX" ; then
-                    if test $compiler_major_version > "5"; then
+                    if test $compiler_major_version -gt "5"; then
                         r="$r -D_DEFAULT_SOURCE"
                     else
                         r="$r -D_BSD_SOURCE"


### PR DESCRIPTION
This is leaving a file by the name of "5" in every directory.