### PR TITLE
Add SessionId support to wsman client

### DIFF
--- a/Unix/tests/wsman/test_wsbuf.cpp
+++ b/Unix/tests/wsman/test_wsbuf.cpp
@@ -508,7 +508,10 @@ NitsTestWithSetup(TestCreateRequest, TestWsbufSetup)
     memset(&cliHeaders.operationTimeout, 0, sizeof(MI_Interval));
     cliHeaders.resourceUri = const_cast<MI_Char*>(ZT("http://schemas.microsoft.com/wbem/wscim/1/cim-schema/2/X_smallNumber"));
     cliHeaders.operationOptions = NULL;
+#ifndef DISABLE_SHELL
     cliHeaders.compressionType = const_cast<MI_Char*>(ZT("xpress"));
+    cliHeaders.sessionId = const_cast<MI_Char*>(ZT("SessionGuid"));
+#endif
 
     if (!NitsCompare(MI_RESULT_OK, WSBuf_Init(&s_buf, 1024), PAL_T("Unable to initialize buffer")))
     {
@@ -528,7 +531,10 @@ NitsTestWithSetup(TestCreateRequest, TestWsbufSetup)
 
     output = BufData(&s_buf);
 
+#ifndef DISABLE_SHELL
     NitsCompareSubstring(output, PAL_T("<h:CompressionType s:mustUnderstand=\"true\">xpress</h:CompressionType>"), ZT("CompressionType"));
+    NitsCompareSubstring(output, PAL_T("<p:SessionId s:mustUnderstand=\"false\">SessionGuid</p:SessionId>"), ZT("SessionId"));
+#endif
 
     Stprintf(expected, MI_COUNT(expected),
              ZT("<a:Action>%T</a:Action>"),

--- a/Unix/wsman/wsbuf.c
+++ b/Unix/wsman/wsbuf.c
@@ -3205,11 +3205,20 @@ static MI_Result WSBuf_CreateRequestHeader(WSBuf *buf,
     }
 
 #ifndef DISABLE_SHELL
-   if (cliHeaders->compressionType)
+    if (cliHeaders->compressionType)
     {
         if (MI_RESULT_OK != WSBuf_AddLit(buf, LIT(ZT("<h:CompressionType s:mustUnderstand=\"true\">"))) ||
             MI_RESULT_OK != WSBuf_AddStringNoEncoding(buf, cliHeaders->compressionType) ||
             MI_RESULT_OK != WSBuf_AddLit(buf, LIT(ZT("</h:CompressionType>"))))
+        {
+            goto failed;
+        }
+    }
+    if (cliHeaders->sessionId)
+    {
+        if (MI_RESULT_OK != WSBuf_AddLit(buf, LIT(ZT("<p:SessionId s:mustUnderstand=\"false\">"))) ||
+            MI_RESULT_OK != WSBuf_AddStringNoEncoding(buf, cliHeaders->sessionId) ||
+            MI_RESULT_OK != WSBuf_AddLit(buf, LIT(ZT("</p:SessionId>"))))
         {
             goto failed;
         }

--- a/Unix/wsman/wsbuf.h
+++ b/Unix/wsman/wsbuf.h
@@ -256,7 +256,10 @@ typedef struct _WsmanClient_Headers
     MI_Char *dataLocale;
     MI_Interval operationTimeout;
     MI_Instance *operationOptions;
+#ifndef DISABLE_SHELL
     MI_Char *compressionType;
+    MI_Char *sessionId;
+#endif
 } WsmanClient_Headers;
 
 MI_Result GetMessageRequest(

--- a/Unix/wsman/wsmanclient.c
+++ b/Unix/wsman/wsmanclient.c
@@ -667,6 +667,17 @@ void _WsmanClient_Post( _In_ Strand* self_, _In_ Message* msg)
         self->wsmanSoapHeaders.action = value.string;
     }
 
+    if ((MI_Instance_GetElement(requestMessage->options,
+        MI_T("__MI_OPERATIONOPTIONS_SESSIONID"),
+        &value,
+        &type,
+        &flags,
+        &index) == MI_RESULT_OK) &&
+        ((flags & MI_FLAG_NULL) != MI_FLAG_NULL) &&
+        (type == MI_STRING))
+    {
+        self->wsmanSoapHeaders.sessionId = value.string;
+    }
     self->wsmanSoapHeaders.operationOptions = requestMessage->options;
 
     miresult = WSBuf_Init(&self->wsbuf, self->wsmanSoapHeaders.maxEnvelopeSize);


### PR DESCRIPTION
SessionId soap header is needed as part of PSRP shell protocol to enable
connect/disconnect logic.

@Microsoft/omi-devs 