### PR TITLE
George/warnings

### DIFF
--- a/Unix/agent/agent.c
+++ b/Unix/agent/agent.c
@@ -23,7 +23,7 @@
 #include <pwd.h>
 #include <grp.h>
 
-STRAND_DEBUGNAME( IdleNotification );
+STRAND_DEBUGNAME( IdleNotification )
 
 typedef struct _AgentData AgentData;
 

--- a/Unix/base/Strand.h
+++ b/Unix/base/Strand.h
@@ -752,67 +752,67 @@ extern char * _StrandMany_BaseEntryOperationDebugInfo[StrandMany_NumEntryOperati
 #endif
 
 #if defined(STRAND_ENABLE_DEBUG)
-#define STRAND_DEBUGNAME( strandName )   const char * _Strand_DebugInfo_##strandName [1] = { #strandName }
+#define STRAND_DEBUGNAME( strandName )   const char * _Strand_DebugInfo_##strandName [1] = { #strandName };
 #else
 #define STRAND_DEBUGNAME( strandName )
 #endif
 
 #if defined(STRAND_ENABLE_DEBUG)
-#define STRAND_DEBUGNAME1( strandName, auxName0 )   const char * _Strand_DebugInfo_##strandName [Strand_NumAuxMethods+1] = { #strandName, #auxName0 }
+#define STRAND_DEBUGNAME1( strandName, auxName0 )   const char * _Strand_DebugInfo_##strandName [Strand_NumAuxMethods+1] = { #strandName, #auxName0 };
 #else
 #define STRAND_DEBUGNAME1( strandName, auxName0 )
 #endif
 
 #if defined(STRAND_ENABLE_DEBUG)
-#define STRAND_DEBUGNAME2( strandName, auxName0, auxName1 )   const char * _Strand_DebugInfo_##strandName [Strand_NumAuxMethods+1] = { #strandName, #auxName0, #auxName1 }
+#define STRAND_DEBUGNAME2( strandName, auxName0, auxName1 )   const char * _Strand_DebugInfo_##strandName [Strand_NumAuxMethods+1] = { #strandName, #auxName0, #auxName1 };
 #else
 #define STRAND_DEBUGNAME2( strandName, auxName0, auxName1 )
 #endif
 
 #if defined(STRAND_ENABLE_DEBUG)
-#define STRAND_DEBUGNAME3( strandName, auxName0, auxName1, auxName2 )   const char * _Strand_DebugInfo_##strandName [Strand_NumAuxMethods+1] = { #strandName, #auxName0, #auxName1, #auxName2 }
+#define STRAND_DEBUGNAME3( strandName, auxName0, auxName1, auxName2 )   const char * _Strand_DebugInfo_##strandName [Strand_NumAuxMethods+1] = { #strandName, #auxName0, #auxName1, #auxName2 };
 #else
 #define STRAND_DEBUGNAME3( strandName, auxName0, auxName1, auxName2 )
 #endif
 
 #if defined(STRAND_ENABLE_DEBUG)
-#define STRAND_DEBUGNAME4( strandName, auxName0, auxName1, auxName2, auxName3 )   const char * _Strand_DebugInfo_##strandName [Strand_NumAuxMethods+1] = { #strandName, #auxName0, #auxName1, #auxName2, #auxName3 }
+#define STRAND_DEBUGNAME4( strandName, auxName0, auxName1, auxName2, auxName3 )   const char * _Strand_DebugInfo_##strandName [Strand_NumAuxMethods+1] = { #strandName, #auxName0, #auxName1, #auxName2, #auxName3 };
 #else
 #define STRAND_DEBUGNAME4( strandName, auxName0, auxName1, auxName2, auxName3 )
 #endif
 
 #if defined(STRAND_ENABLE_DEBUG)
-#define STRAND_DEBUGNAME5( strandName, auxName0, auxName1, auxName2, auxName3, auxName4 )   const char * _Strand_DebugInfo_##strandName [Strand_NumAuxMethods+1] = { #strandName, #auxName0, #auxName1, #auxName2, #auxName3, #auxName4 }
+#define STRAND_DEBUGNAME5( strandName, auxName0, auxName1, auxName2, auxName3, auxName4 )   const char * _Strand_DebugInfo_##strandName [Strand_NumAuxMethods+1] = { #strandName, #auxName0, #auxName1, #auxName2, #auxName3, #auxName4 };
 #else
 #define STRAND_DEBUGNAME5( strandName, auxName0, auxName1, auxName2, auxName3, auxName4 )
 #endif
 
 #if defined(STRAND_ENABLE_DEBUG)
-#define STRAND_DEBUGNAME6( strandName, auxName0, auxName1, auxName2, auxName3, auxName4, auxName5 )   const char * _Strand_DebugInfo_##strandName [StrandBoth_NumAuxMethods+1] = { #strandName, #auxName0, #auxName1, #auxName2, #auxName3, #auxName4, #auxName5 }
+#define STRAND_DEBUGNAME6( strandName, auxName0, auxName1, auxName2, auxName3, auxName4, auxName5 )   const char * _Strand_DebugInfo_##strandName [StrandBoth_NumAuxMethods+1] = { #strandName, #auxName0, #auxName1, #auxName2, #auxName3, #auxName4, #auxName5 };
 #else
 #define STRAND_DEBUGNAME6( strandName, auxName0, auxName1, auxName2, auxName3, auxName4, auxName5 )
 #endif
 
 #if defined(STRAND_ENABLE_DEBUG)
-#define STRAND_DEBUGNAME7( strandName, auxName0, auxName1, auxName2, auxName3, auxName4, auxName5, auxName6 )   const char * _Strand_DebugInfo_##strandName [StrandBoth_NumAuxMethods+1] = { #strandName, #auxName0, #auxName1, #auxName2, #auxName3, #auxName4, #auxName5, #auxName6 }
+#define STRAND_DEBUGNAME7( strandName, auxName0, auxName1, auxName2, auxName3, auxName4, auxName5, auxName6 )   const char * _Strand_DebugInfo_##strandName [StrandBoth_NumAuxMethods+1] = { #strandName, #auxName0, #auxName1, #auxName2, #auxName3, #auxName4, #auxName5, #auxName6 };
 #else
 #define STRAND_DEBUGNAME7( strandName, auxName0, auxName1, auxName2, auxName3, auxName4, auxName5, auxName6 )
 #endif
 
 #if defined(STRAND_ENABLE_DEBUG)
-#define STRAND_DEBUGNAME8( strandName, auxName0, auxName1, auxName2, auxName3, auxName4, auxName5, auxName6, auxName7 )   const char * _Strand_DebugInfo_##strandName [StrandBoth_NumAuxMethods+1] = { #strandName, #auxName0, #auxName1, #auxName2, #auxName3, #auxName4, #auxName5, #auxName6, #auxName7 }
+#define STRAND_DEBUGNAME8( strandName, auxName0, auxName1, auxName2, auxName3, auxName4, auxName5, auxName6, auxName7 )   const char * _Strand_DebugInfo_##strandName [StrandBoth_NumAuxMethods+1] = { #strandName, #auxName0, #auxName1, #auxName2, #auxName3, #auxName4, #auxName5, #auxName6, #auxName7 };
 #else
 #define STRAND_DEBUGNAME8( strandName, auxName0, auxName1, auxName2, auxName3, auxName4, auxName5, auxName6, auxName7 )
 #endif
 
 #if defined(STRAND_ENABLE_DEBUG)
-#define STRAND_DEBUGNAME9( strandName, auxName0, auxName1, auxName2, auxName3, auxName4, auxName5, auxName6, auxName7, auxName8 )   const char * _Strand_DebugInfo_##strandName [StrandBoth_NumAuxMethods+1] = { #strandName, #auxName0, #auxName1, #auxName2, #auxName3, #auxName4, #auxName5, #auxName6, #auxName7, #auxName8 }
+#define STRAND_DEBUGNAME9( strandName, auxName0, auxName1, auxName2, auxName3, auxName4, auxName5, auxName6, auxName7, auxName8 )   const char * _Strand_DebugInfo_##strandName [StrandBoth_NumAuxMethods+1] = { #strandName, #auxName0, #auxName1, #auxName2, #auxName3, #auxName4, #auxName5, #auxName6, #auxName7, #auxName8 };
 #else
 #define STRAND_DEBUGNAME9( strandName, auxName0, auxName1, auxName2, auxName3, auxName4, auxName5, auxName6, auxName7, auxName8 )
 #endif
 
 #if defined(STRAND_ENABLE_DEBUG)
-#define STRAND_DEBUGNAME10( strandName, auxName0, auxName1, auxName2, auxName3, auxName4, auxName5, auxName6, auxName7, auxName8, auxName9 )   const char * _Strand_DebugInfo_##strandName [StrandBoth_NumAuxMethods+1] = { #strandName, #auxName0, #auxName1, #auxName2, #auxName3, #auxName4, #auxName5, #auxName6, #auxName7, #auxName8, #auxName9 }
+#define STRAND_DEBUGNAME10( strandName, auxName0, auxName1, auxName2, auxName3, auxName4, auxName5, auxName6, auxName7, auxName8, auxName9 )   const char * _Strand_DebugInfo_##strandName [StrandBoth_NumAuxMethods+1] = { #strandName, #auxName0, #auxName1, #auxName2, #auxName3, #auxName4, #auxName5, #auxName6, #auxName7, #auxName8, #auxName9 };
 #else
 #define STRAND_DEBUGNAME10( strandName, auxName0, auxName1, auxName2, auxName3, auxName4, auxName5, auxName6, auxName7, auxName8, auxName9 )
 #endif
@@ -878,14 +878,14 @@ extern char * _StrandMany_BaseEntryOperationDebugInfo[StrandMany_NumEntryOperati
 #if defined(STRAND_ENABLE_DEBUG)
 #define STRAND_ASSERTEXECUTING( strand )    DEBUG_ASSERT( ( ReadWithFence(&(strand)->stateScheduled) & BitExecuting ) != 0 )
 #else
-#define STRAND_ASSERTEXECUTING( strand )
+#define STRAND_ASSERTEXECUTING( strand )    ((void)0)
 #endif
 
 #if defined(STRAND_ENABLE_DEBUG)
 void _Strand_AssertOnStrand( _In_ Strand* strand );
 #define STRAND_ASSERTONSTRAND( strand )     _Strand_AssertOnStrand( strand )
 #else
-#define STRAND_ASSERTONSTRAND( strand )
+#define STRAND_ASSERTONSTRAND( strand )    ((void)0)
 #endif
 
 #if defined(STRAND_ENABLE_DEBUG)
@@ -893,7 +893,7 @@ extern void _StrandLogWithName( _In_ Strand* self, _In_ const char * operation )
 #define STRAND_LOGWITHNAME( strand, operation ) \
     _StrandLogWithName( strand, operation )
 #else
-#define STRAND_LOGWITHNAME( strand, operation )
+#define STRAND_LOGWITHNAME( strand, operation )    ((void)0)
 #endif
 
 /*
@@ -924,19 +924,19 @@ DEBUG_ASSERT( (strand)->infoRight.opened || (strand)->base.currentMethodBit == B
 #if defined(STRAND_ENABLE_DEBUG)
 #define STRAND_VERIFYPROPERLYOPENED( strand ) DEBUG_ASSERT( (strand)->info.opened )
 #else
-#define STRAND_VERIFYPROPERLYOPENED( strand )
+#define STRAND_VERIFYPROPERLYOPENED( strand ) ((void)0)
 #endif
 
 #if defined(STRAND_ENABLE_DEBUG)
 #define STRANDBOTH_VERIFYPROPERLYOPENED_LEFT( strand ) DEBUG_ASSERT( (strand)->base.info.opened )
 #else
-#define STRANDBOTH_VERIFYPROPERLYOPENED_LEFT( strand )
+#define STRANDBOTH_VERIFYPROPERLYOPENED_LEFT( strand ) ((void)0)
 #endif
 
 #if defined(STRAND_ENABLE_DEBUG)
 #define STRANDBOTH_VERIFYPROPERLYOPENED_RIGHT( strand ) DEBUG_ASSERT( (strand)->infoRight.opened )
 #else
-#define STRANDBOTH_VERIFYPROPERLYOPENED_RIGHT( strand )
+#define STRANDBOTH_VERIFYPROPERLYOPENED_RIGHT( strand ) ((void)0)
 #endif
 
 //------------------------------------------------------------------------------------------------------------

--- a/Unix/base/helpers.c
+++ b/Unix/base/helpers.c
@@ -1045,7 +1045,7 @@ MI_Result MI_CALL Instance_SetElementFromStringA(
             && ((msgFlags & WSMANFlag) == WSMANFlag))
         {
             size_t sizeIncoming = Tcslen(*data);
-            size_t sizeDec = 0;
+            int sizeDec = 0;
 
 #if defined(CONFIG_ENABLE_WCHAR)
             void* src = PAL_Calloc(sizeIncoming + 1, sizeof(char));

--- a/Unix/base/multiplex.c
+++ b/Unix/base/multiplex.c
@@ -42,8 +42,8 @@ OperationOut;
 **==============================================================================
 */
 
-STRAND_DEBUGNAME( ConnectionIn );
-STRAND_DEBUGNAME( OperationOut );
+STRAND_DEBUGNAME( ConnectionIn )
+STRAND_DEBUGNAME( OperationOut )
 
 /*
 **==============================================================================

--- a/Unix/buildtool
+++ b/Unix/buildtool
@@ -859,6 +859,8 @@ if [ "$arg1" = "cflags" -o "$arg1" = "cxxflags" ]; then
             test -z "$debug_opt" && r="$r -O2"
             test -z "$debug_opt" && r="$r -qcompact"
             test -n "$pic_opt" && r="$r -qpic"
+            ## treat warnings as errors.
+            test -n "$errwarn_opt" && r="$r -qhalt=w"
             r="$r -q32"
             r="$r -Daix"
 
@@ -866,6 +868,8 @@ if [ "$arg1" = "cflags" -o "$arg1" = "cxxflags" ]; then
         HPUX_IA64_HP)
             test -n "$debug_opt" && r="$r -g"
             test -z "$debug_opt" && r="$r -s +O1"
+            ## treat warnings as errors.
+            test -n "$errwarn_opt" && r="$r +We"
             r="$r +DD32"
             r="$r -mt"
             r="$r +Z"
@@ -878,6 +882,8 @@ if [ "$arg1" = "cflags" -o "$arg1" = "cxxflags" ]; then
         HPUX_PARISC_HP)
             test -n "$debug_opt" && r="$r -g +noobjdebug"
             test -z "$debug_opt" && r="$r +O2 -s"
+            ## treat warnings as errors.
+            test -n "$errwarn_opt" && r="$r +We"
             r="$r +Z"
             r="$r +DAportable"
             r="$r -mt"

--- a/Unix/codec/mof/parser/mofparser.c
+++ b/Unix/codec/mof/parser/mofparser.c
@@ -65,7 +65,10 @@ void GlobalFinalize()
 }
 
 #else
-__attribute__((constructor)) void GlobalInitialize()
+#if !defined(aix)
+__attribute__((constructor)) 
+#endif
+void GlobalInitialize()
 {
     g_d.b = Batch_New(MAX_MOFPARSER_PAGE);
     if (!g_d.b)
@@ -99,7 +102,10 @@ __attribute__((constructor)) void GlobalInitialize()
 ** Free global data object
 **
 =============================================================================*/
-__attribute__((destructor)) void GlobalFinalize()
+#if !defined(aix)
+__attribute__((destructor)) 
+#endif
+void GlobalFinalize()
 {
     g_d.inited = MI_FALSE;
     Batch_Delete(g_d.b);

--- a/Unix/disp/agentmgr.c
+++ b/Unix/disp/agentmgr.c
@@ -115,15 +115,15 @@ struct _AgentElem
 #define AGENTELEM_STRANDAUX_CLOSEAGENTITEM 0
 #define AGENTELEM_STRANDAUX_ENTRYACK       1
 
-STRAND_DEBUGNAME2( AgentElem, CloseAgentItem, EntryAck );
+STRAND_DEBUGNAME2( AgentElem, CloseAgentItem, EntryAck )
 
 #define IDLEREQUESTITEM_STRANDAUX_READYTOFINISH 0
 
-STRAND_DEBUGNAME1( IdleRequestItem, ReadyToFinish );
+STRAND_DEBUGNAME1( IdleRequestItem, ReadyToFinish )
 
 #define REQUESTITEM_STRANDAUX_PREPARETOFINISHONERROR 0
 
-STRAND_DEBUGNAME1( RequestItem, PrepareToFinishOnError );
+STRAND_DEBUGNAME1( RequestItem, PrepareToFinishOnError )
 
 
 /*

--- a/Unix/disp/disp.c
+++ b/Unix/disp/disp.c
@@ -25,8 +25,8 @@
 
 #define DISPENUMPARENT_STRANDAUX_ENUMDONE      0
 
-STRAND_DEBUGNAME1( DispEnumParent, EnumDone );
-STRAND_DEBUGNAME( DispEnumEntry );
+STRAND_DEBUGNAME1( DispEnumParent, EnumDone )
+STRAND_DEBUGNAME( DispEnumEntry )
 
 /*
 **==============================================================================

--- a/Unix/disp/disp.c
+++ b/Unix/disp/disp.c
@@ -857,7 +857,7 @@ static MI_Result _HandleEnumerateInstancesReq(
 {
     MI_Result r = MI_RESULT_FAILED;
     MI_Boolean sentOk = MI_FALSE;
-    WQL_Dialect dialect;
+    WQL_Dialect dialect = WQL_DIALECT_WQL;
     DispEnumParent* enumInteraction;
     EnumEntry* enumEntry;
     EnumEntry* enumEntryHead = NULL;

--- a/Unix/http/http.c
+++ b/Unix/http/http.c
@@ -66,7 +66,7 @@ typedef void SSL_CTX;
 
 #define HTTPSOCKET_STRANDAUX_NEWREQUEST 0
 
-STRAND_DEBUGNAME1( HttpSocket, NewRequest );
+STRAND_DEBUGNAME1( HttpSocket, NewRequest )
 
 
 

--- a/Unix/http/httpauth.c
+++ b/Unix/http/httpauth.c
@@ -1001,7 +1001,7 @@ static void _displayStatus(OM_uint32 status_code, int status_type)
     do
     {
         (* _g_gssState.Gss_Display_Status)(&min_status, status_code, status_type, (gss_OID) & mech_ntlm, &message_context, &status_string);
-        trace_HTTP_GssStatus((const int)status_string.length, (char *)status_string.value, min_status);
+        trace_HTTP_GssStatus((int)status_string.length, (char *)status_string.value, min_status);
         (* _g_gssState.Gss_Release_Buffer)(&min_status, &status_string);
 
     }

--- a/Unix/http/httpclientauth.c
+++ b/Unix/http/httpclientauth.c
@@ -1356,8 +1356,8 @@ HttpClient_NextAuthRequest(_In_ struct _HttpClient_SR_SocketData * self, _In_ co
     // gss_OID_set_desc mechset_iakerb = { 1, &mech_iakerb };
     const gss_OID_set_desc mechset_spnego = { 1, (gss_OID) & mech_spnego };
     
-    const gss_OID mechset_krb5_elems[] = { (gss_OID const)&mech_krb5,
-        (gss_OID const)&mech_iakerb
+    const gss_OID mechset_krb5_elems[] = { (gss_OID)&mech_krb5,
+        (gss_OID)&mech_iakerb
     };
     
     const gss_OID_set_desc mechset_krb5 = { 2, (gss_OID) mechset_krb5_elems };
@@ -1520,8 +1520,8 @@ static char *_BuildInitialGssAuthHeader(_In_ HttpClient_SR_SocketData * self, MI
     const gss_OID_desc mech_iakerb = { 6, "\053\006\001\005\002\005" };
     //const gss_OID_set_desc mechset_spnego = { 1, (gss_OID) & mech_spnego };
 
-    const gss_OID mechset_krb5_elems[] = { (gss_OID const)&mech_krb5,
-        (gss_OID const)&mech_iakerb
+    const gss_OID mechset_krb5_elems[] = { (gss_OID)&mech_krb5,
+        (gss_OID)&mech_iakerb
     };
 
     const gss_OID_set_desc mechset_krb5 = { 2, (gss_OID) mechset_krb5_elems };
@@ -1667,7 +1667,7 @@ static char *_BuildInitialGssAuthHeader(_In_ HttpClient_SR_SocketData * self, MI
 
         if (_g_gssClientState.gssSetNegMechs)
         {
-            maj_stat = (*_g_gssClientState.gssSetNegMechs)(&min_stat, cred, (const gss_OID_set)&mechset_avail);
+            maj_stat = (*_g_gssClientState.gssSetNegMechs)(&min_stat, cred, (gss_OID_set)&mechset_avail);
             if (maj_stat != GSS_S_COMPLETE)
             {
                 _ReportError(self, "setting neg mechs", maj_stat, min_stat);

--- a/Unix/indication/indimgr/mgrstrand.c
+++ b/Unix/indication/indimgr/mgrstrand.c
@@ -88,8 +88,8 @@ typedef struct _SubscribeElem
 **==============================================================================
 */
 
-STRAND_DEBUGNAME( SubscribeElem );
-STRAND_DEBUGNAME( SubscribeEntry );
+STRAND_DEBUGNAME( SubscribeElem )
+STRAND_DEBUGNAME( SubscribeEntry )
 
 void _SubscribeElem_Post(_In_ Strand* self_, _In_ Message* msg)
 {

--- a/Unix/miapi/InteractionProtocolHandler.c
+++ b/Unix/miapi/InteractionProtocolHandler.c
@@ -134,7 +134,7 @@ typedef struct _InteractionProtocolHandler_Operation
 
 } InteractionProtocolHandler_Operation;
 
-STRAND_DEBUGNAME(miapiProtocolHandler);
+STRAND_DEBUGNAME(miapiProtocolHandler)
 
 MI_Result InteractionProtocolHandler_Application_IncrementThreadCount(
     _In_     InteractionProtocolHandler_Application *application);

--- a/Unix/omi_error/omierror.c
+++ b/Unix/omi_error/omierror.c
@@ -382,12 +382,15 @@ MI_INLINE const MI_Char *Errno_ToString(
     }
 # else /* defined(CONFIG_ENABLE_WCHAR) */
     {
-        *buffer = '\0';
-
-        // Intentionally disregarding return code
-        (void)strerror_r(OMI_Code, buffer, len) ;
-
+#if defined(macos) || ((_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600) && ! _GNU_SOURCE)
+        int ret = strerror_r(OMI_Code, buffer, len);
+        if (ret != 0)
+            *buffer = '\0';
         return buffer;
+#else
+        char *ret = strerror_r(OMI_Code, buffer, len);
+        return ret;
+#endif
     }
 # endif /* defined(CONFIG_ENABLE_WCHAR) */
 }

--- a/Unix/protocol/protocol.c
+++ b/Unix/protocol/protocol.c
@@ -52,9 +52,9 @@ static const MI_Uint32 _MAGIC = 0xC764445E;
 /*
 **==============================================================================
 */
-STRAND_DEBUGNAME1( ProtocolSocketServer, PostMsg );
-STRAND_DEBUGNAME2( ProtocolFromSocket, PostMsg, ReadyToFinish );
-STRAND_DEBUGNAME3( ProtocolConnector, PostMsg, ReadyToFinish, ConnectEvent );
+STRAND_DEBUGNAME1( ProtocolSocketServer, PostMsg )
+STRAND_DEBUGNAME2( ProtocolFromSocket, PostMsg, ReadyToFinish )
+STRAND_DEBUGNAME3( ProtocolConnector, PostMsg, ReadyToFinish, ConnectEvent )
 
 /*
 **==============================================================================

--- a/Unix/provmgr/context.c
+++ b/Unix/provmgr/context.c
@@ -20,7 +20,7 @@
 #include "nioproc.h"
 #include <omi_error/omierror.h>
 
-STRAND_DEBUGNAME3( Context, TryPostLeft, TryPostLeftNotify, InvokeSubscribe );
+STRAND_DEBUGNAME3( Context, TryPostLeft, TryPostLeftNotify, InvokeSubscribe )
 
 static const MI_Uint32 _MAGIC = 0x35eb3d3b;
 

--- a/Unix/regress
+++ b/Unix/regress
@@ -278,7 +278,7 @@ fi
 ##
 
 rm -rf $prefix
-./configure --prefix=$prefix --outputdirname=$current_output $options
+./configure --enable-werror --prefix=$prefix --outputdirname=$current_output $options
 
 if [ "$?" != "0" ]; then
     echo "$0: configure failed"

--- a/Unix/samples/Providers/TestClass_AllDMTFTypes/TestClass_AllDMTFTypes.cpp
+++ b/Unix/samples/Providers/TestClass_AllDMTFTypes/TestClass_AllDMTFTypes.cpp
@@ -95,10 +95,17 @@ void CreateInstances(MI_Context* context, unsigned int number)
         TestClass_AllDMTFTypes_Set_v_Key(instance, (MI_Uint64) i);
         TestClass_AllDMTFTypes_Set_v_rEal32(instance, (MI_Real32) (1.003E+2 + i));
         TestClass_AllDMTFTypes_Set_v_Real64(instance, (MI_Real64) (1.4234E-2 + i));
+#if defined(hpux)
+#pragma diag_suppress 2068
+//   HP complains about change of sign        
+#endif
         TestClass_AllDMTFTypes_Set_v_sint16(instance, (MI_Sint16) ((0xFF) * -1 + i));
         TestClass_AllDMTFTypes_Set_v_sint32(instance, (MI_Sint32) ((0xFFFF) * -1 + i));
         TestClass_AllDMTFTypes_Set_v_sint64(instance, (MI_Sint64) ((MI_Sint64)(0xFFFFFFFF) * -1 + i));
         TestClass_AllDMTFTypes_Set_v_sint8(instance, (MI_Sint8) ((0xF) * -1 + i));
+#if defined(hpux)
+#pragma diag_default 2068
+#endif
 
         MI_Char strBuf[100];        
         Stprintf(strBuf, MI_COUNT(strBuf), MI_T("TestString %d"), i);

--- a/Unix/server/server.c
+++ b/Unix/server/server.c
@@ -129,7 +129,7 @@ OPTIONS:\n\
     --timestamp                 Print timestamp server was built with.\n\
 \n");
 
-STRAND_DEBUGNAME( NoopRequest );
+STRAND_DEBUGNAME( NoopRequest )
 
 static void FUNCTION_NEVER_RETURNS err(const ZChar* fmt, ...)
 {

--- a/Unix/wql/wql.c
+++ b/Unix/wql/wql.c
@@ -539,8 +539,14 @@ extern int WQL_Eval(
                     return -1;
 
                 {
+#if defined(hpux)
+#pragma diag_suppress 2549
+#endif
                     WQL_Symbol s2 = symbols[--nsymbols];
                     WQL_Symbol s1 = symbols[--nsymbols];
+#if defined(hpux)
+#pragma diag_default 2549
+#endif
                     WQL_Symbol s;
                     int f;
 

--- a/Unix/wsman/wsman.c
+++ b/Unix/wsman/wsman.c
@@ -53,13 +53,13 @@
 
 #define WSMANCONNECTION_STRANDAUX_PROCESSREQUEST                0
 
-STRAND_DEBUGNAME1( WsmanConnection, ProcessRequest );
+STRAND_DEBUGNAME1( WsmanConnection, ProcessRequest )
 
 #define ENUMERATIONCONTEXT_STRANDAUX_PULLATTACHED               0
 #define ENUMERATIONCONTEXT_STRANDAUX_UNSUBSCRIBEATTACHED        1
 #define ENUMERATIONCONTEXT_STRANDAUX_CONNECTION_DATA_TIMEOUT    2
 
-STRAND_DEBUGNAME2( WsmanEnumerationContext, PullAttached, UnsubscribeAttached );
+STRAND_DEBUGNAME2( WsmanEnumerationContext, PullAttached, UnsubscribeAttached )
 
 /*
 **==============================================================================

--- a/Unix/wsman/wsmanclient.c
+++ b/Unix/wsman/wsmanclient.c
@@ -42,7 +42,7 @@ static MI_Boolean WSMAN_UTF16_IMPLEMENTED = FALSE;
 #endif
 
 
-STRAND_DEBUGNAME3( WsmanClientConnector, PostMsg, ReadyToFinish, ConnectEvent );
+STRAND_DEBUGNAME3( WsmanClientConnector, PostMsg, ReadyToFinish, ConnectEvent )
 
 typedef struct _EnumerationState
 {

--- a/Unix/xml/xml.c
+++ b/Unix/xml/xml.c
@@ -75,14 +75,10 @@ static const unsigned char _spaceChar[256] =
 
 INLINE int _IsSpace(XML_Char c)
 {
-#if defined(CONFIG_ENABLE_WCHAR)
-    if (c >= 0 && c < 256)
-        return _spaceChar[(unsigned char)c];
-    else
-        return 0;
-#else
-    return _spaceChar[(unsigned char)c];
-#endif
+    int i = (int) c;
+    if (i >= 0 && i< 256)
+        return _spaceChar[i];
+    return 0;
 }
 
 INLINE int _AllSpace(_In_z_ XML_Char *p, size_t count)
@@ -133,26 +129,18 @@ INLINE XML_Char * _SkipChars(_In_z_ XML_Char* p, size_t count)
 
 INLINE int _IsFirst(XML_Char c)
 {
-#if defined(CONFIG_ENABLE_WCHAR)
-    if (c >= 0 && c < 256)
-        return _nameChar[(unsigned char)c] & 2;
-    else
-        return 0;
-#else
-    return _nameChar[(unsigned char)c] & 2;
-#endif
+    int i = (int) c;
+    if (i >= 0 && i< 256)
+        return _nameChar[i] & 2;
+    return 0;
 }
 
 INLINE int _IsInner(XML_Char c)
 {
-#if defined(CONFIG_ENABLE_WCHAR)
-    if (c >= 0 && c < 256)
-        return _nameChar[(unsigned char)c];
-    else
-        return 0;
-#else
-    return _nameChar[(unsigned char)c];
-#endif
+    int i = (int) c;
+    if (i >= 0 && i< 256)
+        return _nameChar[i];
+    return 0;
 }
 
 INLINE XML_Char* _SkipInner(_In_z_ XML_Char* p)
@@ -310,14 +298,10 @@ static const unsigned char _ReduceAttrValueMatchChars[256] =
 
 INLINE int _ReduceAttrValueMatch(XML_Char c)
 {
-#if defined(CONFIG_ENABLE_WCHAR)
-    if (c >= 0 && c < 256)
-        return _ReduceAttrValueMatchChars[(unsigned char)c];
-    else
-        return 1;
-#else
-    return _ReduceAttrValueMatchChars[(unsigned char)c];
-#endif
+    int i = (int) c;
+    if (i >= 0 && i< 256)
+        return _ReduceAttrValueMatchChars[i];
+    return 0;
 }
 
 /* Reduce entity references and remove leading and trailing whitespace */
@@ -397,14 +381,10 @@ static const unsigned char _ReduceCharDataMatchChars[256] =
 
 INLINE int _ReduceCharDataMatch(XML_Char c)
 {
-#if defined(CONFIG_ENABLE_WCHAR)
-    if (c >= 0 && c < 256)
-        return _ReduceCharDataMatchChars[(unsigned char)c];
-    else
-        return 1;
-#else
-    return _ReduceCharDataMatchChars[(unsigned char)c];
-#endif
+    int i = (int) c;
+    if (i >= 0 && i< 256)
+        return _ReduceCharDataMatchChars[i];
+    return 0;
 }
 
 /* Reduce character data, advance p, and return pointer to end */


### PR DESCRIPTION
1.  Treat compiler warnings as errors on HPUX and AIX.
2.  Treat compiler warnings as errors on last part of regress (output4 builds).
3.  Fix code to not generate warnings.
