### PR TITLE
XML handling of chars outside normal range fail

### DIFF
--- a/Unix/xml/xml.c
+++ b/Unix/xml/xml.c
@@ -384,7 +384,7 @@ INLINE int _ReduceCharDataMatch(XML_Char c)
     int i = (int) c;
     if (i >= 0 && i< 256)
         return _ReduceCharDataMatchChars[i];
-    return 0;
+    return 1;
 }
 
 /* Reduce character data, advance p, and return pointer to end */

--- a/Unix/xmlserializer/xmlserializer.c
+++ b/Unix/xmlserializer/xmlserializer.c
@@ -890,7 +890,7 @@ static void WriteBuffer_Char(
     };
 
     if ((escapingDepth == 0) ||
-        (charToWrite > L'>') ||
+        (((unsigned int)charToWrite) > L'>') ||
         (_encode[(unsigned int)charToWrite].str == NULL))
     {
         WriteBuffer_NoneEscapedChar(clientBuffer, clientBufferLength, clientBufferNeeded, charToWrite, result);


### PR DESCRIPTION
xml.c was a hang, xmlserializer.c was a crash.
Fixes issue #196

@Microsoft/ostc-devs 