### PR TITLE
use -TERM instead of -15 for kill

### DIFF
--- a/Unix/tests/cli/test_cli.cpp
+++ b/Unix/tests/cli/test_cli.cpp
@@ -519,7 +519,7 @@ static int StopServerSudo()
 
         argv[args++] = sudoPath;
         argv[args++] = "kill";
-        argv[args++] = "-15";
+        argv[args++] = "-TERM";
         argv[args++] = pidStr.c_str();
         argv[args++] = NULL;
 


### PR DESCRIPTION
AIX did not seem to like -15 as much

@Microsoft/omi-devs 

pbuild passed across the matrix