### PR TITLE
Remove brew install openssl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,5 @@ addons:
       - libcurl4-openssl-dev
       - time
 
-before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew install openssl ; fi
-
 script: 
       - cd Unix && ./regress


### PR DESCRIPTION
openssl is now installed by default.  Forcing it to install again causes errors in builds.