### PR TITLE
Create NTLM cred file control in omiserver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ nits.log
 /Unix/etc/ssl/certs/omikey.pem
 /Unix/etc/ssl/certs/omi.pem
 /Unix/etc/ssl/certs/omi.der
+/Unix/etc/creds

--- a/Unix/base/oi_traces.h
+++ b/Unix/base/oi_traces.h
@@ -342,6 +342,8 @@ OI_EVENT("Reg file %s is corrupted. It will be skipped by the server")
 void trace_ProvReg_SkipRegFile(const char * filePath);
 OI_EVENT("LIBRARY tag is missing in reg file: %s")
 void trace_RegFile_MissingLibraryTag(const char * filePath);
+OI_EVENT("NTLM Credentials file does not exist or invalid permissions: %s")
+void trace_NtlmCredFileInvalid(const char * ntlmfile);
 
 /******************************** WARNINGS ***********************************/
 
@@ -783,6 +785,10 @@ void trace_NonRootUserAccessInprocProvider(const char* username, const TChar* cl
 
 OI_EVENT("child process with PID=[%d] terminated abnormally")
 void trace_ChildProcessTerminatedAbnormally(int uid);
+
+OI_EVENT("NTLM_USER_FILE environment variable [%s] ignored")
+void trace_NtlmEnvIgnored(const char * ntlm_user_file);
+
 
 /******************************** INFORMATIONAL ***********************************/
 

--- a/Unix/base/oiomi.h
+++ b/Unix/base/oiomi.h
@@ -851,6 +851,12 @@ FILE_EVENT1(20133, trace_ProvReg_SkipRegFile_Impl, LOG_ERR, PAL_T("Reg file %s i
 #endif
 FILE_EVENT1(20134, trace_RegFile_MissingLibraryTag_Impl, LOG_ERR, PAL_T("LIBRARY tag is missing in reg file: %s"), const char *)
 #if defined(CONFIG_ENABLE_DEBUG)
+#define trace_NtlmCredFileInvalid(a0) trace_NtlmCredFileInvalid_Impl(__FILE__, __LINE__, scs(a0))
+#else
+#define trace_NtlmCredFileInvalid(a0) trace_NtlmCredFileInvalid_Impl(0, 0, scs(a0))
+#endif
+FILE_EVENT1(20135, trace_NtlmCredFileInvalid_Impl, LOG_ERR, PAL_T("NTLM Credentials file does not exist or invalid permissions: %s"), const char *)
+#if defined(CONFIG_ENABLE_DEBUG)
 #define trace__FindSubRequest_CannotFindKey(a0, a1, a2) trace__FindSubRequest_CannotFindKey_Impl(__FILE__, __LINE__, a0, a1, a2)
 #else
 #define trace__FindSubRequest_CannotFindKey(a0, a1, a2) trace__FindSubRequest_CannotFindKey_Impl(0, 0, a0, a1, a2)
@@ -2110,6 +2116,12 @@ FILE_EVENT3(30208, trace_NonRootUserAccessInprocProvider_Impl, LOG_WARNING, PAL_
 #define trace_ChildProcessTerminatedAbnormally(a0) trace_ChildProcessTerminatedAbnormally_Impl(0, 0, a0)
 #endif
 FILE_EVENT1(30209, trace_ChildProcessTerminatedAbnormally_Impl, LOG_WARNING, PAL_T("child process with PID=[%d] terminated abnormally"), int)
+#if defined(CONFIG_ENABLE_DEBUG)
+#define trace_NtlmEnvIgnored(a0) trace_NtlmEnvIgnored_Impl(__FILE__, __LINE__, scs(a0))
+#else
+#define trace_NtlmEnvIgnored(a0) trace_NtlmEnvIgnored_Impl(0, 0, scs(a0))
+#endif
+FILE_EVENT1(30210, trace_NtlmEnvIgnored_Impl, LOG_WARNING, PAL_T("NTLM_USER_FILE environment variable [%s] ignored"), const char *)
 #if defined(CONFIG_ENABLE_DEBUG)
 #define trace_Agent_DisconnectedFromServer() trace_Agent_DisconnectedFromServer_Impl(__FILE__, __LINE__)
 #else

--- a/Unix/base/user.h
+++ b/Unix/base/user.h
@@ -148,6 +148,8 @@ int GetUserName(
     uid_t uid, 
     char name[USERNAME_SIZE]);
 
+MI_Boolean ValidateNtlmCredsFile(const char *credFilePath);
+
 #endif
 
 END_EXTERNC

--- a/Unix/build.mak
+++ b/Unix/build.mak
@@ -277,8 +277,8 @@ distcommon:
 	@ rm -rf $(DISTTMPDIR)
 	@ rm -f $(DISTTAR).gz
 	@ mkdir -p $(DISTTMPDIR)/$(DIST)
-	@ cp -r . $(DISTTMPDIR)/$(DIST)/
-	@ rm -rf $(DISTTMPDIR)/$(DIST)/$(OUTPUTDIRNAME)
+	@ sudo cp -rp . $(DISTTMPDIR)/$(DIST)/
+	@ sudo rm -rf $(DISTTMPDIR)/$(DIST)/$(OUTPUTDIRNAME)
 	@ ( cd $(DISTTMPDIR); rm -rf `find . -name CVS` )
 	@ ( cd $(DISTTMPDIR)/$(DIST); rm -rf scriptext )
 	@ ( cd $(DISTTMPDIR)/$(DIST); rm -rf wmiadapter )
@@ -297,7 +297,7 @@ distcommon:
 dist: distcommon
 	@ ( cd $(DISTTMPDIR); tar cf $(DISTTAR) $(DIST) )
 	@ gzip $(DISTTAR)
-	@ rm -rf $(DISTTMPDIR)
+	@ sudo rm -rf $(DISTTMPDIR)
 	@ echo "Created $(DISTTAR).gz"
 
 DISTZIP=$(CONFIGUREDIR)/$(DIST).zip

--- a/Unix/configure
+++ b/Unix/configure
@@ -74,6 +74,7 @@ set_microsoft_build_options()
     localstatedir=/var/opt/omi
     sysconfdir=/etc/opt/omi/conf
     certsdir=/etc/opt/omi/ssl
+    credsdir=/etc/opt/omi/creds
     enable_native_kits=1
 }
 
@@ -530,7 +531,7 @@ if [ "$dev" = "1" ]; then
   bindir=$outputdir/bin
   localstatedir=$outputdir/var
   includedir=$outputdir/include
-  sysconfdir=$root/etc
+  sysconfdir=$outputdir/etc
 fi
 
 ##==============================================================================
@@ -622,6 +623,10 @@ fi
 
 if [ -z "$certsdir" ]; then
     certsdir=$sysconfdir/ssl/certs
+fi
+
+if [ -z "$credsdir" ]; then
+    credsdir=$sysconfdir/creds
 fi
 
 if [ -z "$authdir" ]; then
@@ -727,6 +732,7 @@ mkdir -p $outputdir/var/log
 mkdir -p $outputdir/var/run
 mkdir -p $outputdir/var/omiauth
 mkdir -p $outputdir/include
+mkdir -p $outputdir/etc
 mkdir -p $tmpdir
 
 ##==============================================================================
@@ -1588,6 +1594,7 @@ CONFIG_LOCALSTATEDIR=$localstatedir
 CONFIG_SYSCONFDIR=$sysconfdir
 CONFIG_PROVIDERDIR=$providerdir
 CONFIG_CERTSDIR=$certsdir
+CONFIG_CREDSDIR=$credsdir
 CONFIG_AUTHDIR=$authdir
 CONFIG_NAMESPACE=$namespace
 CONFIG_HTTPPORT=$httpport
@@ -1622,6 +1629,38 @@ EOF
 
 echo "created $fn"
 
+if [ "$dev" = "1" ]; then
+    ##==============================================================================
+    ##
+    ## Copy and modify etc directory contents as needed for dev
+    ##
+    ##==============================================================================
+
+    fn=$outputdir/etc
+
+    sudo cp -p $rootrelative/etc/omiserver.conf $fn
+    sudo cp -p $rootrelative/etc/omicli.conf $fn
+    sudo cp -p $rootrelative/etc/omigen.conf $fn
+    sudo cp -rp $rootrelative/etc/omiregister $fn
+
+    if [ -f $fn/omiserver.conf ]; then
+      echo "created $fn/omiserver.conf"
+      mkdir -p $credsdir
+      cp -rp $rootrelative/etc/creds/* $credsdir
+      sudo chmod 700 $credsdir
+      sudo chown -R root:root $credsdir
+      test -d $credsdir && echo "created $credsdir"
+      
+      echo "NtlmCredsFile=$credsdir/ntlm" >>$fn/omiserver.conf # register the creds file
+    else
+      echo "required file $fn/omiserver.conf not found"
+      exit -1
+    fi
+
+    test -f $fn/omicli.conf && echo "created $fn/omicli.conf"
+    test -f $fn/omigen.conf && echo "created $fn/omigen.conf"
+    test -d $fn/omiregister && echo "created $fn/omiregister"
+fi
 
 ##==============================================================================
 ##
@@ -1647,6 +1686,10 @@ fi
 chmod +w $fnnitsargs
 
 ntlm_supported=`$buildtool ntlm`
+if [ $ntlm_supported ]; then 
+   echo "NTLM auth can be supported on this platform"
+fi
+
 echo "created $fnnitsargs"
 
 ##==============================================================================
@@ -1690,6 +1733,7 @@ cat > $fn <<EOF
 #define CONFIG_SYSCONFDIR "$sysconfdir"
 #define CONFIG_PROVIDERDIR "$providerdir"
 #define CONFIG_CERTSDIR "$certsdir"
+#define CONFIG_CREDSDIR "$credsdir"
 #define CONFIG_AUTHDIR "$authdir"
 #define CONFIG_NAMESPACE "$namespace"
 #define CONFIG_HTTPPORT $httpport
@@ -2025,10 +2069,16 @@ echo "created $fn"
 ##==============================================================================
 
 if [ "$dev" = "1" ]; then
+  mkdir -p $certsdir
+  echo "built certs dir " $certsdir 
   openssl req -x509 -sha1 -newkey rsa:2048 -days 3650 -nodes -config $fn -keyout $certsdir/omikey.pem -out $certsdir/omi.pem
   openssl x509 -outform der -in $certsdir/omi.pem -out $certsdir/omi.der
   chmod 600 $certsdir/omikey.pem
   chmod 644 $certsdir/omi.pem
+  echo "built certs in dir " $certsdir 
+
+else
+  echo "won\'t build certs in " $certsdir 
 fi
 
 ##==============================================================================

--- a/Unix/etc/omiserver.conf
+++ b/Unix/etc/omiserver.conf
@@ -23,7 +23,7 @@
 ##
 ## loglevel -- set the log level of the server
 ##
-loglevel = DEBUG
+loglevel = WARNING
 
 ##
 ## <NICKNAME> -- set the value of nickname.
@@ -51,3 +51,6 @@ loglevel = DEBUG
 #configfile=PATH
 NoSSLv2=true
 #NoSSLv3=false
+#NtlmCredsFile=PATH
+# For example
+#NtlmCredsFile=/etc/opt/omi/.creds/ntlm

--- a/Unix/installbuilder/conf/omiserver.conf
+++ b/Unix/installbuilder/conf/omiserver.conf
@@ -46,3 +46,14 @@ keyfile=/etc/opt/omi/ssl/omikey.pem
 configfile=/etc/opt/omi/conf/omiserver.conf
 #NoSSLv2=true
 #NoSSLv3=false
+# To enable NTLM authentication via negotiation (SPNEGO), specify the location 
+# of the credentials file. This file is in the form
+#
+# <domain>|<username>:<password> 
+#
+# For further information, take a look at the file Unix/doc/setup-ntlm-omi.md
+#
+#
+#NtlmCredsFile=PATH
+# For example
+NtlmCredsFile=/etc/opt/omi/.creds/ntlm

--- a/Unix/miapi/Options.c
+++ b/Unix/miapi/Options.c
@@ -731,9 +731,9 @@ MI_Result MI_CALL GenericOptions_AddCredentials(
         if (credentials->credentials.usernamePassword.password == NULL)
         {
             if (needToAddCredInstance)
-                miResult = MI_Instance_AddElement(credValueInstance, MI_T("Password"), NULL, MI_STRING, MI_FLAG_NULL);
+                miResult = MI_Instance_AddElement(credValueInstance, MI_T("Password"), NULL, MI_UINT8A, MI_FLAG_NULL);
             else
-                miResult = MI_Instance_SetElement(credValueInstance, MI_T("Password"), NULL, MI_STRING, MI_FLAG_NULL);
+                miResult = MI_Instance_SetElement(credValueInstance, MI_T("Password"), NULL, MI_UINT8A, MI_FLAG_NULL);
         }
         else
         {

--- a/Unix/regress
+++ b/Unix/regress
@@ -135,7 +135,7 @@ createlink()
         userhome=`eval echo ~$username`
         if [ -w $userhome ]; then
             new_output="$userhome/$USER-$current_output"
-            rm -rf $new_output
+            sudo rm -rf $new_output
             mkdir $new_output
             if [ $? -eq 0 ]; then
                 ln -s $new_output $current_output
@@ -145,7 +145,7 @@ createlink()
 
 # If that's not available, try /tmp
     new_output="/tmp/$USER-$current_output"
-    rm -rf $new_output
+    sudo rm -rf $new_output
     mkdir $new_output
     if [ $? -eq 0 ]; then
         ln -s $new_output $current_output
@@ -163,7 +163,7 @@ createlink()
 if [ "$run_char" = "1" ]; then
 
 current_output=output1
-rm -rf ./$current_output GNUmakefile
+sudo rm -rf ./$current_output GNUmakefile
 createlink
 $root/configure --dev --outputdirname=$current_output $options
 make world
@@ -174,7 +174,7 @@ if [ "$?" != "0" ]; then
     exit 1
 fi
 
-rm -rf ./$current_output $new_output GNUmakefile
+sudo rm -rf ./$current_output $new_output GNUmakefile
 
 fi
 
@@ -187,7 +187,7 @@ fi
 if [ "$run_wchar" = "1" ]; then
 
 current_output=output2
-rm -rf ./$current_output GNUmakefile
+sudo rm -rf ./$current_output GNUmakefile
 createlink
 $root/configure --dev --enable-wchar --outputdirname=$current_output $options
 make world
@@ -198,7 +198,7 @@ if [ "$?" != "0" ]; then
     exit 1
 fi
 
-rm -rf ./$current_output $new_output GNUmakefile
+sudo rm -rf ./$current_output $new_output GNUmakefile
 
 fi
 
@@ -211,7 +211,7 @@ fi
 if [ "$run_size" = "1" ]; then
 
 current_output=output3
-rm -rf ./$current_output GNUmakefile
+sudo rm -rf ./$current_output GNUmakefile
 createlink
 $root/configure --dev --favorsize --outputdirname=$current_output  $options
 make world
@@ -222,7 +222,7 @@ if [ "$?" != "0" ]; then
     exit 1
 fi
 
-rm -rf ./$current_output $new_output GNUmakefile
+sudo rm -rf ./$current_output $new_output GNUmakefile
 
 fi
 
@@ -235,7 +235,7 @@ fi
 if [ "$run_check" = "1" ]; then
 
 current_output=output4
-rm -rf ./$current_output GNUmakefile
+sudo rm -rf ./$current_output GNUmakefile
 
 # compose omi tar package name
 version="`$root/configure --show-version`"
@@ -249,7 +249,7 @@ make dist
 
 # copy tar package to a temp directory
 checkdir=$root/disttemp
-rm -rf $checkdir
+sudo rm -rf $checkdir
 mkdir $checkdir
 cp $root/$omitarname $checkdir
 
@@ -265,7 +265,7 @@ cd omi-$version
 ##
 
 prefix=/tmp/omi2-$USER
-rm -rf $prefix
+sudo rm -rf $prefix
 
 if [ -d "$prefix" ]; then
     echo "$0: failed: directory already exists (please remove and retry): $prefix"
@@ -277,7 +277,7 @@ fi
 ## configure:
 ##
 
-rm -rf $prefix
+sudo rm -rf $prefix
 ./configure --enable-werror --prefix=$prefix --outputdirname=$current_output $options
 
 if [ "$?" != "0" ]; then
@@ -318,7 +318,7 @@ make install
 
 if [ "$?" != "0" ]; then
     echo "$0: make install failed"
-    rm -rf $prefix
+    sudo rm -rf $prefix
     cleanup ./$current_output
     exit 1
 fi
@@ -331,7 +331,7 @@ mkdir $prefix/ocsprovider
 
 if [ "$?" != "0" ]; then
     echo "$0: failed to create $prefix/oscprovider directory"
-    rm -rf $prefix
+    sudo rm -rf $prefix
     cleanup ./$current_output
     exit 1
 fi
@@ -342,7 +342,7 @@ EOF
 
 if [ "$?" != "0" ]; then
     echo "$0: failed to create schema.mof"
-    rm -rf $prefix
+    sudo rm -rf $prefix
     cleanup ./$current_output
     exit 1
 fi
@@ -354,7 +354,7 @@ $prefix/bin/omigen --cpp -m oscprovider ./schema.mof OMI_ComputerSystem
 
 if [ "$?" != "0" ]; then
     echo "$0: failed to generate provider"
-    rm -rf $prefix
+    sudo rm -rf $prefix
     cleanup ./$current_output
     exit 1
 fi
@@ -367,7 +367,7 @@ make
 
 if [ "$?" != "0" ]; then
     echo "$0: failed to build provider"
-    rm -rf $prefix
+    sudo rm -rf $prefix
     cleanup ./$current_output
     exit 1
 fi
@@ -380,7 +380,7 @@ make reg
 
 if [ "$?" != "0" ]; then
     echo "$0: failed to register provider"
-    rm -rf $prefix
+    sudo rm -rf $prefix
     cleanup ./$current_output
     exit 1
 fi
@@ -398,7 +398,7 @@ $prefix/bin/omiserver -i -d --livetime 60 --httpport 0 --httpsport 0
 
 if [ "$?" != "0" ]; then
     echo "$0: failed to start server"
-    rm -rf $prefix
+    sudo rm -rf $prefix
     cleanup ./$current_output
     exit 1
 fi
@@ -413,7 +413,7 @@ $prefix/bin/omicli ei root/cimv2 OMI_ComputerSystem
 
 if [ "$?" != "7" ]; then
     echo "$0: failed to enumerate instances of OMI_ComputerSystem"
-    rm -rf $prefix
+    sudo rm -rf $prefix
     cleanup ./$current_output
     exit 1
 fi
@@ -426,7 +426,7 @@ $prefix/bin/omiserver -s
 
 if [ "$?" != "0" ]; then
     echo "$0: failed to stop the server"
-    rm -rf $prefix
+    sudo rm -rf $prefix
     cleanup ./$current_output
     exit 1
 fi
@@ -436,10 +436,10 @@ fi
 ##
 
 cd $savedir
-rm -rf $prefix
-rm -rf ./$current_output GNUmakefile
+sudo rm -rf $prefix
+sudo rm -rf ./$current_output GNUmakefile
 cd ../..
-rm -rf $root/$omitarname $root/GNUmakefile $checkdir
+sudo rm -rf $root/$omitarname $root/GNUmakefile $checkdir
 
 fi
 

--- a/Unix/tools/auth_tests_cleanup.sh
+++ b/Unix/tools/auth_tests_cleanup.sh
@@ -2,13 +2,6 @@
 # 
 # output directory and its softlink target are the two arguments
 
-ntlm_file=$1/tmp/ntlm
-
-if [ -f $ntlm_file ]; then
-    echo "Removing NTLM file: $ntlm_file"
-    rm -f $ntlm_file
-fi
-
 # Don't do cleanup for now since output is useful for debugging
 #rm -rf $1 $2
 

--- a/Unix/tools/auth_tests_setup.sh
+++ b/Unix/tools/auth_tests_setup.sh
@@ -2,14 +2,17 @@
 #
 # Used by regress and 'make tests'.  Should be run at omi/Unix level.
 
-basedir=`basename ${PWD}`
-if [ "$basedir" != "Unix" ]; then
-    echo "Must be run from omi/Unix directory."
-    exit 1
+
+if [ -z $outputdir ]; then
+   outputdir=$1
 fi
 
-if [ "x$OUTPUTDIR" = "x" ]; then
-    echo "Must be run from make or regress."
+echo "OUTPUTDIR = " $outputdir
+
+basedir=`basename ${PWD}`
+
+if [ "$basedir" != "Unix" ]; then
+    echo "Must be run from omi/Unix directory."
     exit 1
 fi
 
@@ -37,34 +40,61 @@ do
 done
 
 #
-# if required env variables don't exist, then quit
+# Setup the NTLM auth file for client and server. They must be different files because 
+# if the differeing permissions, as the server file must be owned by root and the client by
+# the user.
 #
+# If there is already a cred file present we defer to it. In configure we possibly copied over
+# a prebuilt cred file for the server from Unix/etc/creds. If such a file exists, it must contain the test
+# credentials. The source of the cred file is contained in Unix/etc/creds. The destination is defined by 
+# configure --dev. The credfile is not defined in non-dev build environments.
+#
+# If the server cred file isn't present we build one with the test credentials, derived from OMI_USER and 
+# OMI_PASSWORD env variables.
+#
+# We create the cred file for the client and point to it with the NTLM_USER_FILE env variable.  This prevents us 
+# from clobbering the credentials in ~/.omi/
+#
+# Once we have created the cred files, they are static unless removed, edited, or configured via
+# configure. We always set the ownership and r/w permissions.
+
 if [ "x${username}" != "x" -a "x${userpasswd}" != "x" ]; then
     SUDO_PATH=`which sudo`
     export SUDO_PATH
 
 ## NTLM setup
-
     
-    ntlm_cred_dir=$OUTPUTDIR/tmp/creds
-    ntlm_file=$OUTPUTDIR/tmp/creds/ntlm
+    # client side creds
+    echo "build cred files"
+
+    client_ntlm_cred_dir=$outputdir/tmp/creds
+    client_ntlm_file=$outputdir/tmp/creds/ntlm
     hostname=`uname -n`
-    if [ -f $ntlm_cred_dir ]; then
-        sudo rm -rf $ntlm_cred_dir
+    if [ ! -f $client_ntlm_file ]; then
+       echo "build client auth file " $client_ntlm_file
+
+       mkdir -p $outputdir/etc
+       mkdir -p $client_ntlm_cred_dir
+       echo $hostname":"$username":"$userpasswd > $client_ntlm_file
+
     fi
+    chmod 700 $client_ntlm_cred_dir
+    chmod 600 $client_ntlm_file
 
-    mkdir $ntlm_cred_dir
-    echo $hostname":"$username":"$userpasswd > $ntlm_file
-
-    chmod 700 $ntlm_cred_dir
-    chmod 600 $ntlm_file
-
-    NTLM_USER_FILE=$ntlm_file
+    NTLM_USER_FILE=$client_ntlm_file
     export NTLM_USER_FILE
-    NTLM_DOMAIN=$hostname
-    export NTLM_DOMAIN
+
+    # server side 
+    # configure already created the dir
+
+    server_ntlm_file=$outputdir/etc/creds/ntlm
+    if sudo test ! -f $server_ntlm_file ; then
+       echo "build server auth file " $server_ntlm_file
+       sudo cp $client_ntlm_file $server_ntlm_file
+    else 
+       echo "do not build server auth file " $server_ntlm_file
+    fi
+    sudo chown root:root $server_ntlm_file
+    sudo chmod 600 $server_ntlm_file
 fi
 
-supported=`./buildtool ntlm`
-NTLM_SUPPORTED_PLATFORM=$supported
-export NTLM_SUPPORTED_PLATFORM

--- a/Unix/tools/make_tests.sh
+++ b/Unix/tools/make_tests.sh
@@ -5,16 +5,28 @@
 # Three position parameters are required.  Format of command is:
 #      make_tests.sh $(LIBDIR) $(BINDIR) $(TMPDIR)
 
-. ./tools/auth_tests_setup.sh
+libdir=$1
+bindir=$2
+tmpdir=$3
 
-LD_LIBRARY_PATH=$1
+dir=`pwd`
+cd "${libdir}"
+cd ..
+outputdir=`pwd`
+cd $dir
+
+echo "make tests, outputdir = " $outputdir
+
+. ./tools/auth_tests_setup.sh $outputdir
+
+LD_LIBRARY_PATH=$libdir
 export LD_LIBRARY_PATH
-DYLD_FALLBACK_LIBRARY_PATH=$1
+DYLD_FALLBACK_LIBRARY_PATH=$libdir
 export DYLD_FALLBACK_LIBRARY_PATH
-DYLD_LIBRARY_PATH=$1
+DYLD_LIBRARY_PATH=$libdir
 export DYLD_LIBRARY_PATH
 
-$2/nits -file:$3/nitsargs.txt
+$bindir/nits -file:$tmpdir/nitsargs.txt
 e=$?
 
 ./tools/auth_tests_cleanup.sh


### PR DESCRIPTION
@Microsoft/omi-devs 

Elminates the need  for  the NTLM_USER_FILE env var.
Ignores NTLM_USER_FILE if set