### PR TITLE
Update AIX systems to require AIX 1.0.x

### DIFF
--- a/Unix/installbuilder/GNUmakefile
+++ b/Unix/installbuilder/GNUmakefile
@@ -28,7 +28,7 @@ ifeq ($(PF),Linux)
 DATAFILES += Linux.data
 endif
 ifeq ($(PF),AIX)
-DATAFILES += AIX.data
+DATAFILES += AIX.data AIX_$(PF_MAJOR).data
 endif
 ifeq ($(PF),HPUX)
 DATAFILES += HPUX.data

--- a/Unix/installbuilder/datafiles/AIX_6.data
+++ b/Unix/installbuilder/datafiles/AIX_6.data
@@ -1,4 +1,5 @@
 %Dependencies
-*prereq openssl.base 0.9.8.4
+%% openssl.base 1.0.*.* (1.0.1.517 was initial release)
+*prereq openssl.base v=1 r=0
 *prereq xlC.rte 9.0.0.2
 *prereq bos.rte.libc 5.3.0.65

--- a/Unix/installbuilder/datafiles/AIX_7.data
+++ b/Unix/installbuilder/datafiles/AIX_7.data
@@ -1,4 +1,5 @@
 %Dependencies
-*prereq openssl.base 0.9.8.1300
+%% openssl.base 1.0.*.* (1.0.1.517 was initial release)
+*prereq openssl.base v=1 r=0
 *prereq xlC.rte 11.1.0.1
 *prereq bos.rte.libc 7.1.0.1


### PR DESCRIPTION
IBM is dropping support for AIX 0.9.8, and openssl.base,
version 1.0.1.517 is the first release of OpenSSL 1.0.x
for all AIX platforms (5.3, 6.1, and 7.1).

@Microsoft/omi-devs @Microsoft/ostc-devs 