### PR TITLE
Modify configure script to abort if SSL 1.0.x not installed on AIX

### DIFF
--- a/Unix/configure
+++ b/Unix/configure
@@ -1344,6 +1344,46 @@ rm -f $tmpdir/pthread_rwlock_t_func
 
 ##==============================================================================
 ##
+## Check whether SSL 1.0.x is installed on AIX platforms
+##
+##==============================================================================
+
+echo $echon "checking if SSL 1.0.x is installed on AIX platform ... $echoc"
+
+if echo $platform | grep "AIX_" > /dev/null 2> /dev/null; then
+    cat > $tmpdir/aixsslversion.c <<EOF
+int main()
+{
+    #include <openssl/opensslv.h>
+
+    // SSL version is encoded like MNNFFPPS: major minor fix patch status
+    // We only care about the major/minor version (SSL 1.0.*) ...
+
+    #if OPENSSL_VERSION_NUMBER >= 0x10000000L && OPENSSL_VERSION_NUMBER <= 0x100fffffL
+        return 123;
+    #else
+        #error "SSL Version 1.0.* is not installed on this system"
+    #endif
+}
+EOF
+
+    ( cd $tmpdir ; $cc $cprogflags $cflags -o aixsslversion aixsslversion.c > /dev/null 2> /dev/null )
+
+    if [ "$?" = "0" ]; then
+        echo "yes"
+    else
+        echo "no"
+        exit 1
+    fi
+
+    rm $tmpdir/aixsslversion.c
+    rm $tmpdir/aixsslversion
+else
+    echo "N/A"
+fi
+
+##==============================================================================
+##
 ## gss library name
 ##
 ##==============================================================================

--- a/Unix/configure
+++ b/Unix/configure
@@ -1388,7 +1388,6 @@ fi
 ##
 ##==============================================================================
 
-echo "OS: " $os
 case $os in
         LINUX)
             if [ disable_auth != 1 ]
@@ -2110,15 +2109,11 @@ echo "created $fn"
 
 if [ "$dev" = "1" ]; then
   mkdir -p $certsdir
-  echo "built certs dir " $certsdir 
   openssl req -x509 -sha1 -newkey rsa:2048 -days 3650 -nodes -config $fn -keyout $certsdir/omikey.pem -out $certsdir/omi.pem
   openssl x509 -outform der -in $certsdir/omi.pem -out $certsdir/omi.der
   chmod 600 $certsdir/omikey.pem
   chmod 644 $certsdir/omi.pem
-  echo "built certs in dir " $certsdir 
-
-else
-  echo "won\'t build certs in " $certsdir 
+  echo "built certificates in directory: " $certsdir 
 fi
 
 ##==============================================================================


### PR DESCRIPTION
Verify that SSL 1.0.x is installed on AIX platforms.
Also cleaned up configure output (commented on code review, but corrections not made).

@Microsoft/omi-devs @Microsoft/ostc-devs 