### PR TITLE
miapi crashed on a connection failure for https

### DIFF
--- a/Unix/http/httpclient.c
+++ b/Unix/http/httpclient.c
@@ -734,7 +734,7 @@ static Http_CallbackResult _ReadHeader(
                     };
 
                 LOGD2((ZT("_ReadHeader - ACCESS DENIED reslt = %d"), rslt));
-                (*self->callbackOnStatus)(self, self->callbackData, MI_RESULT_ACCESS_DENIED, NULL, &AUTH_ERROR);
+                (*self->callbackOnStatus)(self, self->callbackData, MI_RESULT_ACCESS_DENIED, MI_T("Authentication Failure"), &AUTH_ERROR);
                 return rslt;
             }
             break;
@@ -880,7 +880,7 @@ static Http_CallbackResult _ReadData(
 
         /* status callback */
         handler->status = MI_RESULT_OK;
-        (*self->callbackOnStatus)( self, self->callbackData, MI_RESULT_OK, NULL, NULL);
+        (*self->callbackOnStatus)( self, self->callbackData, MI_RESULT_OK, MI_T("Failed to read data from the host"), NULL);
     }
 
 
@@ -2561,7 +2561,7 @@ MI_Result HttpClient_New_Connector2(
                      MI_T("Could not connect") 
                };
 
-            (*self->callbackOnStatus)(self, self->callbackData, MI_RESULT_FAILED, NULL, &CONNECT_ERROR);
+            (*self->callbackOnStatus)(self, self->callbackData, MI_RESULT_FAILED, MI_T("Could not connect"), &CONNECT_ERROR);
 
             HttpClient_Delete(self);
             LOGE2((ZT("HttpClient_New_Connector - _CreateConnectorSocket failed. result: %d (%s)"), r, mistrerror(r)));

--- a/Unix/tests/cli/test_cli.cpp
+++ b/Unix/tests/cli/test_cli.cpp
@@ -1609,7 +1609,7 @@ NitsTestWithSetup(TestOMICLI33_GetInstanceWsmanFailBasicAuth, TestCliSetupSudo)
                  httpPort);
 
         string expect = string("");
-        string expected_err = string("omicli: result: MI_RESULT_ACCESS_DENIED\n");
+        string expected_err = string("omicli: result: MI_RESULT_ACCESS_DENIED\nomicli: result: Authentication Failure\n");
         NitsCompare(InhaleTestFile("TestOMICLI33.txt", expect), true, MI_T("Inhale failure"));
         NitsCompare(Exec(buffer, out, err), 2, MI_T("Omicli error"));
         NitsCompareString(out.c_str(), expect.c_str(), MI_T("Output mismatch"));

--- a/Unix/wsman/wsmanclient.c
+++ b/Unix/wsman/wsmanclient.c
@@ -1442,7 +1442,9 @@ finished:
 
 finished2:
     PostResult(self, MI_T("Unable to create new WsMan connector"), miresult, &cause);
-    return miresult;
+    /* We reported the error via strand so we return SUCCESS to indicate that here */
+    /* There is no connector though so it knows to not do anything else at this point */
+    return MI_RESULT_OK;
 }
 
 MI_Result WsmanClient_Delete(WsmanClient *self)


### PR DESCRIPTION
When an error is sent via the strand in the underlying transport the
code path needs to be a little different because the client can close
the operation out from under our feet. This change makes that happen so
we don't try and use the operation after that point.

#237 
@Microsoft/omi-devs 