### PR TITLE
Deprecate wchar builds for regress and configure

### DIFF
--- a/Unix/configure
+++ b/Unix/configure
@@ -166,10 +166,6 @@ do
       enable_werror=1
       ;;
 
-    --enable-wchar)
-      enable_wchar=1
-      ;;
-
     --enable-gcov)
       enable_gcov=1
       ;;
@@ -354,7 +350,6 @@ OPTIONS:
     --disable-rtti          Disable C++ RTTI support.
     --disable-templates     Disable C++ templates support.
     --enable-werror         Treat warnings as errors.
-    --enable-wchar          Use 'wchar_t' character type [char].
     --target=TARGET         Cross-compiler for the given platform.
     --prefix=PATH           The installation prefix [/opt/omi-$version]
     --libdir=PATH           Install library components here [*/lib].
@@ -1649,7 +1644,6 @@ CONFIG_HTTPSPORT=$httpsport
 ENABLE_DEBUG=$enable_debug
 ENABLE_GCOV=$enable_gcov
 ENABLE_WERROR=$enable_werror
-ENABLE_WCHAR=$enable_wchar
 ENABLE_32BIT=$enable_32bit
 DISABLE_RTTI=$disable_rtti
 DISABLE_LIBPATH=$disable_libpath
@@ -1790,11 +1784,7 @@ cat > $fn <<EOF
 #define CONFIG_SUPPORTS_NTLM $ntlm_supported
 EOF
 
-if [ "$enable_wchar" = "1" ]; then
-    echo "#define CONFIG_UUID L\"$configuuid\"" >>$fn
-else
     echo "#define CONFIG_UUID \"$configuuid\"" >>$fn
-fi
 
 if [ "$enable_debug" = "1" ]; then
     echo "#define CONFIG_ENABLE_DEBUG" >> $fn
@@ -1812,12 +1802,6 @@ if [ "$enable_werror" = "1" ]; then
     echo "#define CONFIG_ENABLE_WERROR" >> $fn
 else
     echo "/* #define CONFIG_ENABLE_WERROR */" >> $fn
-fi
-
-if [ "$enable_wchar" = "1" ]; then
-    echo "#define CONFIG_ENABLE_WCHAR" >> $fn
-else
-    echo "/* #define CONFIG_ENABLE_WCHAR */" >> $fn
 fi
 
 if [ "$disable_rtti" = "1" ]; then
@@ -2030,10 +2014,6 @@ rm -rf $fn
 echo "#define MI_MAJOR $major" >> $fn
 echo "#define MI_MINOR $minor" >> $fn
 echo "#define MI_REVISION $revision" >> $fn
-
-if [ "$enable_wchar" = "1" ]; then
-    cat $root/common/MI_wchar.h.in >> $fn
-fi
 
 cat $root/common/MI.h >> $fn
 

--- a/Unix/configure-wchar
+++ b/Unix/configure-wchar
@@ -1,2 +1,0 @@
-#!/bin/sh
-./configure-world --enable-wchar

--- a/Unix/regress
+++ b/Unix/regress
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 run_char=1
-run_wchar=1
 run_size=1
 run_check=1
 current_output=output
@@ -26,7 +25,6 @@ do
 
     --runs=*)
         run_char=0
-        run_wchar=0
         run_size=0
         run_check=0
         runs=`echo $arg | sed 's/:/ /g'`
@@ -36,9 +34,6 @@ do
                 char)
                     run_char=1
                     ;;
-                wchar)
-                    run_wchar=1
-                    ;;
                 size)
                     run_size=1
                     ;;
@@ -47,7 +42,6 @@ do
                     ;;
                 all)
                     run_char=1
-                    run_wchar=1
                     run_size=1
                     run_check=1
                     ;;
@@ -90,14 +84,13 @@ OPTIONS:
     --runs=TESTNAME(S)  Run only those test runs
 TESTNAME(S):
     char                  run (single byte) char tests run
-    wchar                 run wchar tests run
     size                  run (optimized for) size tests run
     check                 run check tests run
-    all                   run all test runs (char, wchar, size, check)
+    all                   run all test runs (char, size, check)
 
 Examples:
        ./regress
-       ./regress --runs=char:wchar
+       ./regress --runs=char
        
 EOF
     exit 0
@@ -171,30 +164,6 @@ make world
 if [ "$?" != "0" ]; then
     echo "$0: failed 'world' tests"
     cleanup $current_output
-    exit 1
-fi
-
-sudo rm -rf ./$current_output $new_output GNUmakefile
-
-fi
-
-##==============================================================================
-##
-## 'wchar' tests:
-##
-##==============================================================================
-
-if [ "$run_wchar" = "1" ]; then
-
-current_output=output2
-sudo rm -rf ./$current_output GNUmakefile
-createlink
-$root/configure --dev --enable-wchar --outputdirname=$current_output $options
-make world
-
-if [ "$?" != "0" ]; then
-    echo "$0: failed 'wchar' tests"
-    cleanup  $current_output
     exit 1
 fi
 


### PR DESCRIPTION
Disable wchar option on configure and regress so we no longer validate
this build flavor. This is an unused flavor of OMI so there is no point
in maintaining compatibility. It has been left in the files as commented
out in case we do need to re-enable it.
Fixes issue #273 
@Microsoft/omi-devs 