### PR TITLE
Issue 218: fix provder not load error present to user

### DIFF
--- a/Unix/agent/agent.c
+++ b/Unix/agent/agent.c
@@ -164,6 +164,7 @@ static void _RequestCallback(
     else
     {
         MI_Result result;
+        MI_Char* errmsg = NULL;
         ProvRegEntry regentry;
         RequestMsg* request = (RequestMsg*)interactionParams->msg;
 
@@ -173,12 +174,12 @@ static void _RequestCallback(
         regentry.libraryName = request->libraryName;
         regentry.instanceLifetimeContext = request->instanceLifetimeContext;
 
-        result = ProvMgr_NewRequest(&s_data.provmgr, &regentry, interactionParams );
+        result = ProvMgr_NewRequest(&s_data.provmgr, &regentry, interactionParams, &errmsg );
 
         if (MI_RESULT_OK != result)
         {
             trace_Agent_ProvMgrNewRequest_Failed( result );
-            Strand_FailOpenWithResult(interactionParams, result, PostResultMsg_NewAndSerialize);
+            Strand_FailOpenWithResult(interactionParams, result, errmsg, PostResultMsg_NewAndSerialize);
         }
     }
 }

--- a/Unix/base/Strand.h
+++ b/Unix/base/Strand.h
@@ -1476,6 +1476,7 @@ typedef PostResultMsg* (*MakeResultMessageCallback)(
 void Strand_FailOpenWithResult(
     _In_ InteractionOpenParams*  params,
     MI_Result result,
+    _In_opt_ MI_Char* errmsg,
     _In_ MakeResultMessageCallback callback);
 
 //------------------------------------------------------------------------------------------------------------

--- a/Unix/base/strand.c
+++ b/Unix/base/strand.c
@@ -3215,11 +3215,12 @@ void Strand_FailOpenWithMsg(
 void Strand_FailOpenWithResult(
     _In_ InteractionOpenParams*  params,
     MI_Result result,
+    _In_opt_ MI_Char* errmsg,
     _In_ MakeResultMessageCallback callback)
 {
     PostResultMsg* resultMsg;
 
-    resultMsg = (*callback)( params->msg, NULL, NULL, MI_RESULT_TYPE_MI, result);
+    resultMsg = (*callback)( params->msg, NULL, errmsg, MI_RESULT_TYPE_MI, result);
 
     if( NULL != resultMsg )
     {

--- a/Unix/disp/agentmgr.c
+++ b/Unix/disp/agentmgr.c
@@ -1330,19 +1330,21 @@ void AgentMgr_OpenCallback(
     _Inout_ InteractionOpenParams* params )
 {
     MI_Result result;
+    MI_Char* errmsg = NULL;
     AgentMgr_OpenCallbackData* callbackData = (AgentMgr_OpenCallbackData*)params->callbackData;
 
-    result = AgentMgr_HandleRequest( callbackData->self, params, callbackData->proventry );
+    result = AgentMgr_HandleRequest( callbackData->self, params, callbackData->proventry, &errmsg );
     if( MI_RESULT_OK != result )
     {
-        Strand_FailOpenWithResult(params, result, PostResultMsg_NewAndSerialize);
+        Strand_FailOpenWithResult(params, result, errmsg, PostResultMsg_NewAndSerialize);
     }
 }
 
 MI_Result AgentMgr_HandleRequest(
     _In_ AgentMgr* self,
     _Inout_ InteractionOpenParams* params,
-    _In_ const ProvRegEntry* proventry)
+    _In_ const ProvRegEntry* proventry,
+    _Out_ MI_Char** errmsg)
 {
     MI_Result result = MI_RESULT_OK;
     AgentElem* agent;
@@ -1407,7 +1409,8 @@ MI_Result AgentMgr_HandleRequest(
         return ProvMgr_NewRequest(
             &self->provmgr,
             proventry,
-            params );
+            params,
+            errmsg );
     }
 
     if (proventry->hosting == PROV_HOSTING_USER)
@@ -1524,7 +1527,8 @@ MI_Result AgentMgr_HandleRequest(
     return ProvMgr_NewRequest(
             &self->provmgr,
             proventry,
-            params );
+            params,
+            errmsg );
 #endif
 }
 

--- a/Unix/disp/agentmgr.h
+++ b/Unix/disp/agentmgr.h
@@ -85,6 +85,7 @@ void AgentMgr_OpenCallback(
 MI_Result AgentMgr_HandleRequest(
     _In_ AgentMgr* self,
     _Inout_ InteractionOpenParams* params,
-    _In_ const ProvRegEntry* proventry);
+    _In_ const ProvRegEntry* proventry,
+    _Out_ MI_Char** errmsg);
 
 #endif /* _omi_agentmgr_h */

--- a/Unix/disp/disp.h
+++ b/Unix/disp/disp.h
@@ -64,6 +64,7 @@ MI_Result Disp_Destroy(
 
 MI_Result Disp_HandleInteractionRequest(
     _In_ Disp* self,
-    _Inout_ InteractionOpenParams* params );
+    _Inout_ InteractionOpenParams* params,
+    _Out_ MI_Char** errmsg );
 
 #endif /* _omi_disp_h */

--- a/Unix/provmgr/context.c
+++ b/Unix/provmgr/context.c
@@ -2059,7 +2059,7 @@ void Context_CompleteOpen(
     {
         // Just destroy the context
         _Context_Destroy(self);
-        Strand_FailOpenWithResult(params, result, PostResultMsg_NewAndSerialize);
+        Strand_FailOpenWithResult(params, result,  NULL, PostResultMsg_NewAndSerialize);
     }
 }
 

--- a/Unix/provmgr/provmgr.c
+++ b/Unix/provmgr/provmgr.c
@@ -417,7 +417,8 @@ static MI_Result MI_CALL _GetProviderByClassName(
     _In_ const ProvRegEntry* proventry,
     _In_ MI_ConstString cn,
     _In_ Message* request,
-    _Out_ Provider** provOut)
+    _Out_ Provider** provOut,
+    _Out_ MI_Char** errmsg )
 {
     Library* lib;
     Provider* prov;
@@ -431,6 +432,15 @@ static MI_Result MI_CALL _GetProviderByClassName(
         if (!lib)
         {
             trace_OpenProviderLib_Failed(scs(proventry->libraryName));
+            int size = 128;
+			MI_Char buf[size];
+            *errmsg = Batch_Tcsdup(request->batch, buf);
+            
+            if(*errmsg)
+            {
+                Stprintf(*errmsg, sizeof(buf)/sizeof(buf[0]), PAL_T("Failed to load provider %s."), proventry->libraryName);
+            }
+            
             return MI_RESULT_FAILED;
         }
     }
@@ -992,7 +1002,8 @@ static MI_Result _HandleGetInstanceReq(
     _In_ ProvMgr* self,
     _In_ const ProvRegEntry* proventry,
     _Inout_ InteractionOpenParams* interactionParams,
-    _Out_ Provider** prov)
+    _Out_ Provider** prov,
+    _Out_ MI_Char** errmsg )
 {
     MI_Instance* inst;
     MI_Result r;
@@ -1011,7 +1022,8 @@ static MI_Result _HandleGetInstanceReq(
         proventry,
         className,
         &msg->base.base,
-        prov);
+        prov,
+        errmsg);
 
     if ( MI_RESULT_OK != r )
         return r;
@@ -1175,7 +1187,8 @@ static MI_Result _HandleGetClassReq(
     _In_ ProvMgr* self,
     _In_ const ProvRegEntry* proventry,
     _Inout_ InteractionOpenParams* interactionParams,
-    _Out_ Provider** prov)
+    _Out_ Provider** prov,
+    _Out_ MI_Char** errmsg )
 {
     MI_Result r;
     MI_Class resultClass;
@@ -1192,8 +1205,9 @@ static MI_Result _HandleGetClassReq(
         proventry,
         msg->className,
         &msg->base.base,
-        prov);
-
+        prov,
+        errmsg );
+    
     if ( MI_RESULT_OK != r )
         return r;
 
@@ -1216,7 +1230,8 @@ static MI_Result _HandleCreateInstanceReq(
     _In_ ProvMgr* self,
     _In_ const ProvRegEntry* proventry,
     _Inout_ InteractionOpenParams* interactionParams,
-    _Out_ Provider** prov)
+    _Out_ Provider** prov,
+    _Out_ MI_Char** errmsg )
 {
     MI_Instance* inst;
     MI_Result r;
@@ -1235,7 +1250,8 @@ static MI_Result _HandleCreateInstanceReq(
         proventry,
         className,
         &msg->base.base,
-        prov);
+        prov,
+        errmsg );
 
     if ( MI_RESULT_OK != r )
         return r;
@@ -1277,7 +1293,8 @@ static MI_Result _HandleModifyInstanceReq(
     _In_ ProvMgr* self,
     _In_ const ProvRegEntry* proventry,
     _Inout_ InteractionOpenParams* interactionParams,
-    _Out_ Provider** prov)
+    _Out_ Provider** prov,
+    _Out_ MI_Char** errmsg )
 {
     MI_Instance* inst;
     MI_Result r;
@@ -1296,7 +1313,8 @@ static MI_Result _HandleModifyInstanceReq(
         proventry,
         className,
         &msg->base.base,
-        prov);
+        prov,
+        errmsg );
 
     if ( MI_RESULT_OK != r )
         return r;
@@ -1341,7 +1359,8 @@ static MI_Result _HandleDeleteInstanceReq(
     _In_ ProvMgr* self,
     _In_ const ProvRegEntry* proventry,
     _Inout_ InteractionOpenParams* interactionParams,
-    _Out_ Provider** prov)
+    _Out_ Provider** prov,
+    _Out_ MI_Char** errmsg )
 {
     MI_Instance* inst;
     MI_Result r;
@@ -1360,7 +1379,8 @@ static MI_Result _HandleDeleteInstanceReq(
         proventry,
         className,
         &msg->base.base,
-        prov);
+        prov,
+        errmsg );
 
     if ( MI_RESULT_OK != r )
         return r;
@@ -1408,7 +1428,8 @@ static MI_Result _HandleSubscribeReq(
     _In_ ProvMgr* self,
     _In_ const ProvRegEntry* proventry,
     _Inout_ InteractionOpenParams* interactionParams,
-    _Out_ Provider** prov)
+    _Out_ Provider** prov,
+    _Out_ MI_Char** errmsg )
 {
     MI_Result r;
     SubscribeReq* msg = (SubscribeReq*)interactionParams->msg;
@@ -1421,7 +1442,8 @@ static MI_Result _HandleSubscribeReq(
         proventry,
         msg->className,
         &msg->base.base,
-        prov);
+        prov,
+        errmsg );
 
     if ( MI_RESULT_OK != r )
     {
@@ -1438,7 +1460,8 @@ static MI_Result _HandleInvokeReq(
     _In_ ProvMgr* self,
     _In_ const ProvRegEntry* proventry,
     _Inout_ InteractionOpenParams* interactionParams,
-    _Out_ Provider** prov)
+    _Out_ Provider** prov,
+    _Out_ MI_Char** errmsg )
 {
     MI_Instance* inst = 0;
     MI_Instance* instParams = 0;
@@ -1469,7 +1492,8 @@ static MI_Result _HandleInvokeReq(
         proventry,
         cn,
         &msg->base.base,
-        prov);
+        prov,
+        errmsg);
 
     if ( MI_RESULT_OK != r )
         return r;
@@ -1557,7 +1581,8 @@ static MI_Result _HandleEnumerateInstancesReq(
     _In_ ProvMgr* self,
     _In_ const ProvRegEntry* proventry,
     _Inout_ InteractionOpenParams* interactionParams,
-    _Out_ Provider** prov)
+    _Out_ Provider** prov,
+    _Out_ MI_Char** errmsg )
 {
     Context* ctx;
     MI_Result r;
@@ -1580,7 +1605,8 @@ static MI_Result _HandleEnumerateInstancesReq(
                 proventry,
                 msg->className,
                 &msg->base.base,
-                prov);
+                prov,
+                errmsg );
 
         if ( MI_RESULT_OK != r )
             return r;
@@ -1650,7 +1676,8 @@ static MI_Result MI_CALL _HandleAssociatorsOfReq(
     _In_ ProvMgr* self,
     _In_ const ProvRegEntry* proventry,
     _Inout_ InteractionOpenParams* interactionParams,
-    _Out_ Provider** prov)
+    _Out_ Provider** prov,
+    _Out_ MI_Char** errmsg )
 {
     Context* ctx;
     MI_Result r;
@@ -1663,7 +1690,8 @@ static MI_Result MI_CALL _HandleAssociatorsOfReq(
         proventry,
         msg->className,
         &msg->base.base,
-        prov);
+        prov,
+        errmsg );
 
     if ( MI_RESULT_OK != r )
         return r;
@@ -1683,7 +1711,8 @@ static MI_Result MI_CALL _HandleAssociatorsOfReq(
             proventry,
             ((Instance*) msg->instance)->classDecl->name,
             &msg->base.base,
-            &provInst );
+            &provInst,
+            errmsg );
 
         if ( MI_RESULT_OK != r )
             return r;
@@ -1736,7 +1765,8 @@ static MI_Result _HandleReferencesOfReq(
     _In_ ProvMgr* self,
     _In_ const ProvRegEntry* proventry,
     _Inout_ InteractionOpenParams* interactionParams,
-    _Out_ Provider** prov)
+    _Out_ Provider** prov,
+    _Out_ MI_Char** errmsg )
 {
     Context* ctx;
     MI_Result r;
@@ -1749,7 +1779,8 @@ static MI_Result _HandleReferencesOfReq(
         proventry,
         msg->className,
         &msg->base.base,
-        prov );
+        prov,
+        errmsg );
 
     if ( MI_RESULT_OK != r )
         return r;
@@ -1769,7 +1800,8 @@ static MI_Result _HandleReferencesOfReq(
             proventry,
             ((Instance*) msg->instance)->classDecl->name,
             &msg->base.base,
-            &provInst );
+            &provInst,
+            errmsg );
 
         if ( MI_RESULT_OK != r )
             return r;
@@ -2117,9 +2149,10 @@ MI_Result ProvMgr_Destroy(
 MI_Result MI_CALL ProvMgr_NewRequest(
     _In_ ProvMgr* self,
     _In_ const ProvRegEntry* proventry,
-    _Inout_ InteractionOpenParams* params )
+    _Inout_ InteractionOpenParams* params,
+    _Out_ MI_Char** errmsg )
 {
-    Provider* prov = 0;
+    Provider* prov = NULL;
     MI_Result r = MI_RESULT_INVALID_PARAMETER;
 
 
@@ -2132,12 +2165,12 @@ MI_Result MI_CALL ProvMgr_NewRequest(
     {
         case GetInstanceReqTag:
         {
-            r = _HandleGetInstanceReq(self, proventry, params, &prov);
+            r = _HandleGetInstanceReq(self, proventry, params, &prov, errmsg);
             break;
         }
         case GetClassReqTag:
         {
-            r = _HandleGetClassReq(self, proventry, params, &prov);
+            r = _HandleGetClassReq(self, proventry, params, &prov, errmsg);
             break;
         }
         case CreateInstanceReqTag:
@@ -2145,12 +2178,12 @@ MI_Result MI_CALL ProvMgr_NewRequest(
         case ShellCreateReqTag:
 #endif
         {
-            r = _HandleCreateInstanceReq(self, proventry, params, &prov);
+            r = _HandleCreateInstanceReq(self, proventry, params, &prov, errmsg);
             break;
         }
         case ModifyInstanceReqTag:
         {
-            r = _HandleModifyInstanceReq(self, proventry, params, &prov);
+            r = _HandleModifyInstanceReq(self, proventry, params, &prov, errmsg);
             break;
         }
         case DeleteInstanceReqTag:
@@ -2158,7 +2191,7 @@ MI_Result MI_CALL ProvMgr_NewRequest(
         case ShellDeleteReqTag:
 #endif
         {
-            r = _HandleDeleteInstanceReq(self, proventry, params, &prov);
+            r = _HandleDeleteInstanceReq(self, proventry, params, &prov, errmsg);
             break;
         }
         case InvokeReqTag:
@@ -2172,28 +2205,28 @@ MI_Result MI_CALL ProvMgr_NewRequest(
         case ShellCommandReqTag:
 #endif
         {
-            r = _HandleInvokeReq(self, proventry, params, &prov);
+            r = _HandleInvokeReq(self, proventry, params, &prov, errmsg);
             break;
         }
         case EnumerateInstancesReqTag:
         {
-            r = _HandleEnumerateInstancesReq(self, proventry, params, &prov);
+            r = _HandleEnumerateInstancesReq(self, proventry, params, &prov, errmsg);
             break;
         }
         case AssociatorsOfReqTag:
         {
-            r = _HandleAssociatorsOfReq(self, proventry, params, &prov);
+            r = _HandleAssociatorsOfReq(self, proventry, params, &prov, errmsg);
             break;
         }
         case ReferencesOfReqTag:
         {
-            r = _HandleReferencesOfReq(self, proventry, params, &prov);
+            r = _HandleReferencesOfReq(self, proventry, params, &prov, errmsg);
             break;
         }
 #ifndef DISABLE_INDICATION
         case SubscribeReqTag:
         {
-            r = _HandleSubscribeReq(self, proventry, params, &prov);
+            r = _HandleSubscribeReq(self, proventry, params, &prov, errmsg);
             break;
         }
 #endif

--- a/Unix/provmgr/provmgr.h
+++ b/Unix/provmgr/provmgr.h
@@ -77,7 +77,8 @@ MI_Result ProvMgr_Destroy(
 MI_Result ProvMgr_NewRequest(
     _In_ ProvMgr* self,
     _In_ const ProvRegEntry* proventry,
-    _Inout_ InteractionOpenParams* params );
+    _Inout_ InteractionOpenParams* params,
+    _Out_ MI_Char** errmsg );
 
 typedef struct _ProvMgr_OpenCallbackData
 {
@@ -90,12 +91,13 @@ void ProvMgr_OpenCallback(
     _Inout_ InteractionOpenParams* params )
 {
     MI_Result result;
+    MI_Char* errmsg = NULL;
     ProvMgr_OpenCallbackData* data =  (ProvMgr_OpenCallbackData*)params->callbackData;
 
-    result = ProvMgr_NewRequest( data->self, data->provRegEntry, params );
+    result = ProvMgr_NewRequest( data->self, data->provRegEntry, params, &errmsg );
     if( MI_RESULT_OK != result )
     {
-        Strand_FailOpenWithResult(params, result, PostResultMsg_NewAndSerialize);
+        Strand_FailOpenWithResult(params, result, errmsg, PostResultMsg_NewAndSerialize);
     }
 }
 

--- a/Unix/server/server.c
+++ b/Unix/server/server.c
@@ -302,6 +302,7 @@ static void _RequestCallback(
     ServerCallbackData* self = (ServerCallbackData*)interactionParams->callbackData;
     Message* msg = interactionParams->msg;
     MI_Result result;
+    MI_Char* errmsg = NULL;
 
     DEBUG_ASSERT( NULL != interactionParams );
     DEBUG_ASSERT( NULL != msg );
@@ -322,11 +323,12 @@ static void _RequestCallback(
     Lock_Acquire(&s_disp_mutex);
     result = Disp_HandleInteractionRequest(
                 &self->data->disp, 
-                interactionParams );
+                interactionParams,
+                &errmsg );
     Lock_Release(&s_disp_mutex);
     if( result != MI_RESULT_OK )
     {
-        Strand_FailOpenWithResult(interactionParams, result, PostResultMsg_NewAndSerialize);
+        Strand_FailOpenWithResult(interactionParams, result, errmsg, PostResultMsg_NewAndSerialize);
     }
 }
  

--- a/Unix/tests/indication/test_mgr.cpp
+++ b/Unix/tests/indication/test_mgr.cpp
@@ -771,7 +771,7 @@ MI_EXTERN_C void _UT_HandleRequest(
         /* Terminate the operation if failed in HandleRequest */
         trace_UT_HandleRequestFailed(
             context, interactionParams->msg, MessageName(interactionParams->msg->tag), interactionParams->interaction, response->mrHandleRequest);
-        Strand_FailOpenWithResult(interactionParams,response->mrHandleRequest, PostResultMsg_NewAndSerialize);
+        Strand_FailOpenWithResult(interactionParams,response->mrHandleRequest, NULL, PostResultMsg_NewAndSerialize);
         return;
     }
 
@@ -785,7 +785,7 @@ MI_EXTERN_C void _UT_HandleRequest(
     NitsAssert( NULL != ssa, PAL_T("Failed to create StrandSimAgentMgr"));
     if (NULL == ssa)
     {
-        Strand_FailOpenWithResult(interactionParams,MI_RESULT_SERVER_LIMITS_EXCEEDED, PostResultMsg_NewAndSerialize);
+        Strand_FailOpenWithResult(interactionParams,MI_RESULT_SERVER_LIMITS_EXCEEDED, NULL, PostResultMsg_NewAndSerialize);
         return;
     }
 
@@ -814,7 +814,7 @@ MI_EXTERN_C void _UT_HandleRequest(
                 NitsAssert(NULL != res, PAL_T("Failed to create PostResultMsg message"));
                 if (!res)
                 {
-                    Strand_FailOpenWithResult(interactionParams,MI_RESULT_SERVER_LIMITS_EXCEEDED, PostResultMsg_NewAndSerialize);
+                    Strand_FailOpenWithResult(interactionParams,MI_RESULT_SERVER_LIMITS_EXCEEDED, NULL, PostResultMsg_NewAndSerialize);
                     return;
                 }
 
@@ -829,7 +829,7 @@ MI_EXTERN_C void _UT_HandleRequest(
                 NitsAssert(NULL != res, PAL_T("Failed to create PostResultMsg message"));
                 if (!res)
                 {
-                    Strand_FailOpenWithResult(interactionParams,MI_RESULT_SERVER_LIMITS_EXCEEDED, PostResultMsg_NewAndSerialize);
+                    Strand_FailOpenWithResult(interactionParams,MI_RESULT_SERVER_LIMITS_EXCEEDED, NULL, PostResultMsg_NewAndSerialize);
                     return;
                 }
                 ssa->response->muResponseMsgSent ++;
@@ -840,7 +840,7 @@ MI_EXTERN_C void _UT_HandleRequest(
         break;
     default:
         NitsAssert(PAL_FALSE, PAL_T("_UT_HandleRequest: Unrecognized message"));
-        Strand_FailOpenWithResult(interactionParams,MI_RESULT_FAILED, PostResultMsg_NewAndSerialize);
+        Strand_FailOpenWithResult(interactionParams,MI_RESULT_FAILED, NULL, PostResultMsg_NewAndSerialize);
         return;
     }
 }

--- a/Unix/tests/provmgr/test_provmgr.cpp
+++ b/Unix/tests/provmgr/test_provmgr.cpp
@@ -711,6 +711,7 @@ NitsTest(TestProvMgr_NewRequest_Reject_NULL_Input)
 {
     InteractionOpenParams params;
     ProvRegEntry entry;
+    MI_Char* errmsg = NULL;
 
     memset(&entry, 0, sizeof(entry));
     entry.libraryName = TestProvMgr_LibraryName;
@@ -720,19 +721,22 @@ NitsTest(TestProvMgr_NewRequest_Reject_NULL_Input)
     NitsAssert( MI_RESULT_INVALID_PARAMETER == ProvMgr_NewRequest(
         NULL,
         &entry,
-        NULL ),
+        NULL,
+        &errmsg ),
         PAL_T("Expected invalid arg"));
 
     NitsAssert( MI_RESULT_INVALID_PARAMETER == ProvMgr_NewRequest(
         &s_provmgr,
         &entry,
-        NULL ),
+        NULL,
+        &errmsg ),
         PAL_T("Expected invalid arg"));
 
     NitsAssert( MI_RESULT_INVALID_PARAMETER == ProvMgr_NewRequest(
         &s_provmgr,
         &entry,
-        &params ),
+        &params,
+        &errmsg ),
         PAL_T("Expected invalid arg"));
 }
 NitsEndTest


### PR DESCRIPTION
I have fixed present the error to user when a provider cannot be found or loaded, @Microsoft/omi-devs , could you help to review this PR?
before fix:
```
/opt/omi-1.0.8/bin/omicli: result: MI_RESULT_FAILED
/opt/omi-1.0.8/bin/omicli: result: A general error occurred, not covered by a more specific error code.
instance of OMI_Error
{
    OwningEntity=OMI:CIMOM
    MessageID=OMI:MI_Result:1
    Message=A general error occurred, not covered by a more specific error code.
    MessageArguments={}
    PerceivedSeverity=7
    ProbableCause=0
    ProbableCauseDescription=Unknown
    CIMStatusCode=1
    OMI_Code=1
    OMI_Category=0
    OMI_Type=MI
    OMI_ErrorMessage=A general error occurred, not covered by a more specific error code.
}
```

After fix:
```
/opt/omi-1.0.8/bin/omicli: result: MI_RESULT_FAIL_LOAD_PROVIDER
/opt/omi-1.0.8/bin/omicli: result: The CIM server failed to load provider.
instance of OMI_Error
{
    OwningEntity=OMI:CIMOM
    MessageID=OMI:MI_Result:29
    Message=The CIM server failed to load provider.
    MessageArguments={}
    PerceivedSeverity=7
    ProbableCause=0
    ProbableCauseDescription=Unknown
    CIMStatusCode=29
    OMI_Code=29
    OMI_Category=21
    OMI_Type=MI
    OMI_ErrorMessage=The CIM server failed to load provider.
}
```