### PR TITLE
Fix SLIST on PPC due to memory cache problems

### DIFF
--- a/Unix/pal/slist.c
+++ b/Unix/pal/slist.c
@@ -15,13 +15,17 @@ PAL_INLINE void Atomic_Lock(
     _Inout_ volatile ptrdiff_t* dest)
 {
     while (Atomic_Swap(dest, 1) == 1)
-        while (*dest)
+        while (Atomic_Read(dest))
             ;
+    /* Make sure that all memory is synchronized with our processor */
+    NonX86MemoryBarrier();
 }
 
 PAL_INLINE void Atomic_Unlock(
     _Inout_ volatile ptrdiff_t* dest)
 {
+    /* Make sure that all memory is synchronized with other  processors*/
+    NonX86MemoryBarrier();
     Atomic_Swap(dest, 0);
 }
 


### PR DESCRIPTION
Memory ordering on PPC is different to X86/AMD and so just because one
chunk of memory is synchronized does not mean others are. This change
adds a memory block around the locking and unlocking of the SLIST so all
relevant memory in the SLIST is properly pulled into the processor
memory cache.

@Microsoft/omi-devs 