### PR TITLE
Fix AIX libgssapi library loading

### DIFF
--- a/Unix/configure
+++ b/Unix/configure
@@ -1402,7 +1402,7 @@ case $os in
             if [ disable_auth != 1 ]
             then
                 gsslib=gssapi_krb5
-                gsslibpath=libgssapi_krb5
+                gsslibpath="/usr/lib/libgssapi_krb5.a(libgssapi_krb5.a.so)"
             fi
             ;;
         SUNOS)

--- a/Unix/http/httpauth.c
+++ b/Unix/http/httpauth.c
@@ -158,6 +158,8 @@ typedef struct _Gss_Extensions {
 static Gss_Extensions _g_gssState = { 0 };
 
 static struct _Once g_once_state = ONCE_INITIALIZER;
+static const char GSS_LIBRARY_NAME[] = CONFIG_GSSLIB;
+
 
 void _GssUnloadLibrary()
 {
@@ -179,7 +181,11 @@ int _GssInitLibrary(_In_ void *data, _Outptr_result_maybenull_ void **value)
     }
     _g_gssState.gssLibLoaded = LOADING;
 
-    void *libhandle = dlopen(CONFIG_GSSLIB, RTLD_NOW | RTLD_GLOBAL);
+#ifdef aix
+   void *libhandle =  dlopen(GSS_LIBRARY_NAME, RTLD_NOW | RTLD_MEMBER);
+#else
+   void *libhandle =  dlopen(GSS_LIBRARY_NAME, RTLD_NOW | RTLD_GLOBAL);
+#endif
     void *fn_handle = NULL;
 
     trace_HTTP_LoadingGssApi(CONFIG_GSSLIB);

--- a/Unix/http/httpclientauth.c
+++ b/Unix/http/httpclientauth.c
@@ -476,7 +476,11 @@ static _Success_(return == 0) int _GssClientInitLibrary( _In_ void* data, _Outpt
    }
    _g_gssClientState.gssLibLoaded = LOADING;
 
+#ifdef aix
+   void *libhandle =  dlopen(GSS_LIBRARY_NAME, RTLD_NOW | RTLD_MEMBER);
+#else
    void *libhandle =  dlopen(GSS_LIBRARY_NAME, RTLD_NOW | RTLD_GLOBAL);
+#endif
    void *fn_handle = NULL;
 
    trace_HTTP_LoadingGssApi(CONFIG_GSSLIB);


### PR DESCRIPTION
We are currently failing to load the libgssapi_krb5 library because AIX uses shared objects in an archive file for some reason. This requires different flags and file name to load.  With this fix, AIX loads the file correctly. 