### PR TITLE
Add enum operation for filesystem provider

### DIFF
--- a/Unix/samples/Providers/FileSystem/MSFT_Directory.c
+++ b/Unix/samples/Providers/FileSystem/MSFT_Directory.c
@@ -115,7 +115,16 @@ void MI_CALL MSFT_Directory_EnumerateInstances(
     MI_Boolean keysOnly,
     const MI_Filter* filter)
 {
-    MI_PostResult(context, MI_RESULT_NOT_SUPPORTED);
+    MSFT_Directory inst;
+
+    if (!ConstructDirectory(&inst, MI_T("/"), context))
+    {
+        MI_PostResult(context, MI_RESULT_FAILED);
+        return;
+    }
+
+    MSFT_Directory_Post(&inst, context);
+    MI_PostResult(context, MI_RESULT_OK);
 }
 
 void MI_CALL MSFT_Directory_GetInstance(


### PR DESCRIPTION
Because we need this operation to test Associators from Windows to Linux
and the Associators on Windows needs Get-CimInstance command which do enum operation

@Microsoft/omi-devs , could you help to review? This is for supporting automation, thank you!