### PR TITLE
Fixes kinit when cred cache is reset or expired

### DIFF
--- a/Unix/tools/auth_tests_setup.sh
+++ b/Unix/tools/auth_tests_setup.sh
@@ -105,6 +105,8 @@ if [ "x${username}" != "x" -a "x${userpasswd}" != "x" ]; then
         export OMI_KRB_RUN_TESTS
     else
         unset OMI_KRB_RUN_TESTS
+        #  Just do the kinit initally to prime the cred cache 
+        echo ${userpasswd} | kinit ${username}
         if klist -s ; then
            # There is a ticket granting ticket in the credential cache. 
            # We expect that kerberos has been set up but we need to see if the user 


### PR DESCRIPTION
It works well enough we need to make sure solaris and aix machines have the kerberos tests turned off by the environment variable OMI_KRB_TESTS_ENABLED=FALSE in /etc/profile.  I have done this for any machines I use.