### PR TITLE
Authentication and test changes for macos

### DIFF
--- a/Unix/tests/cli/TestOMICLI37.mac.txt
+++ b/Unix/tests/cli/TestOMICLI37.mac.txt
@@ -1,0 +1,15 @@
+instance of OMI_Error
+{
+    OwningEntity=OMI:CIMOM
+    MessageID=OMI:MI_Result:1
+    Message=acquiring creds with password failed  No credentials were supplied, or the credentials were unavailable or inaccessible. unknown mech-code 0 for mech unknown
+    MessageArguments={}
+    PerceivedSeverity=7
+    ProbableCause=117
+    ProbableCauseDescription=acquiring creds with password failed  No credentials were supplied, or the credentials were unavailable or inaccessible. unknown mech-code 0 for mech unknown
+    CIMStatusCode=1
+    OMI_Code=1
+    OMI_Category=0
+    OMI_Type=MI
+    OMI_ErrorMessage=A general error occurred, not covered by a more specific error code.
+}

--- a/Unix/tests/cli/test_cli.cpp
+++ b/Unix/tests/cli/test_cli.cpp
@@ -2261,7 +2261,11 @@ NitsTestWithSetup(TestOMICLI37_GetInstanceWsmanFailKerberosAuth, TestCliSetupSud
 
         string expect = string("");
         string expected_err = string("omicli: result: MI_RESULT_ACCESS_DENIED\n");
+#if defined(macos)
+        NitsCompare(InhaleTestFile("TestOMICLI37.mac.txt", expect), true, MI_T("Inhale failure"));
+#else
         NitsCompare(InhaleTestFile("TestOMICLI37.txt", expect), true, MI_T("Inhale failure"));
+#endif
         NitsCompare(Exec(buffer, out, err), 2, MI_T("Omicli error"));
         NitsCompareString(out.c_str(), expect.c_str(), MI_T("Output mismatch"));
         NitsCompareSubstring(err.c_str(), expected_err.c_str(), MI_T("Error output mismatch"));
@@ -2332,7 +2336,11 @@ NitsTestWithSetup(TestOMICLI39_GetInstanceWsmanFailKerberosAuthSSL, TestCliSetup
 
         string expect = string("");
         string expected_err = string("omicli: result: MI_RESULT_ACCESS_DENIED\n");
+#if defined(macos)
+        NitsCompare(InhaleTestFile("TestOMICLI37.mac.txt", expect), true, MI_T("Inhale failure"));
+#else
         NitsCompare(InhaleTestFile("TestOMICLI37.txt", expect), true, MI_T("Inhale failure"));
+#endif
         NitsCompare(Exec(buffer, out, err), 2, MI_T("Omicli error"));
         NitsCompareString(out.c_str(), expect.c_str(), MI_T("Output mismatch"));
         NitsCompareSubstring(err.c_str(), expected_err.c_str(), MI_T("Error output mismatch"));
@@ -2352,7 +2360,11 @@ NitsTestWithSetup(TestOMICLI40_GetInstanceWsmanKerberosAuthWithEncrypt, TestCliS
 {
 
     /* Disabled until encrypt issues addressed */
+#if defined(macos)
+    if (false)
+#else
     if (runKrbTests && startServer && !travisCI)
+#endif
     {
         NitsDisableFaultSim;
 
@@ -2406,7 +2418,11 @@ NitsTestWithSetup(TestOMICLI41_GetInstanceWsmanFailKerberosAuthWithEncrypt, Test
 
         string expect = string("");
         string expected_err = string("omicli: result: MI_RESULT_ACCESS_DENIED\n");
+#if defined(macos)
+        NitsCompare(InhaleTestFile("TestOMICLI37.mac.txt", expect), true, MI_T("Inhale failure"));
+#else
         NitsCompare(InhaleTestFile("TestOMICLI37.txt", expect), true, MI_T("Inhale failure"));
+#endif
         NitsCompare(Exec(buffer, out, err), 2, MI_T("Omicli error"));
         NitsCompareString(out.c_str(), expect.c_str(), MI_T("Output mismatch"));
         NitsCompareSubstring(err.c_str(), expected_err.c_str(), MI_T("Error output mismatch"));
@@ -2477,7 +2493,11 @@ NitsTestWithSetup(TestOMICLI45_GetInstanceWsmanFailKerberosAuthNoEncrypt, TestCl
 
         string expect = string("");
         string expected_err = string("omicli: result: MI_RESULT_ACCESS_DENIED\n");
+#if defined(macos)
+        NitsCompare(InhaleTestFile("TestOMICLI37.mac.txt", expect), true, MI_T("Inhale failure"));
+#else
         NitsCompare(InhaleTestFile("TestOMICLI37.txt", expect), true, MI_T("Inhale failure"));
+#endif
         NitsCompare(Exec(buffer, out, err), 2, MI_T("Omicli error"));
         NitsCompareString(out.c_str(), expect.c_str(), MI_T("Output mismatch"));
         NitsCompareSubstring(err.c_str(), expected_err.c_str(), MI_T("Error output mismatch"));

--- a/Unix/tools/auth_tests_setup.sh
+++ b/Unix/tools/auth_tests_setup.sh
@@ -105,30 +105,26 @@ if [ "x${username}" != "x" -a "x${userpasswd}" != "x" ]; then
         export OMI_KRB_RUN_TESTS
     else
         unset OMI_KRB_RUN_TESTS
-        #  Just do the kinit initally to prime the cred cache 
-        echo ${userpasswd} | kinit ${username}
-        if klist -s ; then
-           # There is a ticket granting ticket in the credential cache. 
-           # We expect that kerberos has been set up but we need to see if the user 
-           # exists. However, there aren't many good ways to do that. So for now if the 
-           # kinit succeeds we figure everything is correctly set up. We may or may not 
-           # be correct here.  There is an environment variable to turn all of the kerb tests off 
-           # on a given host if needs be.
-           echo ${userpasswd} | kinit ${username}
-           if [ $? -ge 0 ] ; then
-               echo "Kerberos Tests Enabled"
-               OMI_KRB_RUN_TESTS="true"
-               export OMI_KRB_RUN_TESTS
-               # Tis is hard-coded here, but won't always be. In the meantime we can 
-               # pretend its being checked in the tests themselves
-               OMI_KRB_TESTS_REALM="SCX.COM"
-               export OMI_KRB_TESTS_REALM
-           else
-               echo "Kerberos Tests Disabled Because cannot kinit ${username}"
-           fi
-        else
-            echo "Kerberos Tests Disabled Because cred cache out of date"
-        fi
+        OS=`uname -s`
+
+       if [ "$OS" = "Darwin" ] ; then 
+          # kinit on the mac does not allow the passwd to be piped
+          $(dirname $0)/kinit.exp ${username}  ${userpasswd}
+       else
+          #  Just do the kinit initally to prime the cred cache 
+          echo ${userpasswd} | kinit ${username}
+       fi
+       if [ $? -eq 0 ] ; then
+           echo "Kerberos Tests Enabled"
+           OMI_KRB_RUN_TESTS="true"
+           export OMI_KRB_RUN_TESTS
+           # Tis is hard-coded here, but won't always be. In the meantime we can 
+           # pretend its being checked in the tests themselves
+           OMI_KRB_TESTS_REALM="SCX.COM"
+           export OMI_KRB_TESTS_REALM
+       else
+           echo "Kerberos Tests Disabled Because cannot kinit ${username}"
+       fi
     fi
 fi
 

--- a/Unix/tools/kinit.exp
+++ b/Unix/tools/kinit.exp
@@ -1,0 +1,18 @@
+#!/usr/bin/expect
+
+set timeout 20
+set user     [lindex $argv 0]
+set password [lindex $argv 1]
+
+spawn /usr/bin/kinit "$user"
+
+expect "password:"
+
+send "$password\r";
+
+expect {
+   "incorrect" { exit 1 }
+   default     { exit 0 }
+}
+interact
+


### PR DESCRIPTION
This enables macos to linux or windows connectivity with kerberos authentication. 

It does not implement http encryption from mac OS to windows.. 