### PR TITLE
support omiserver respawn via upstart

### DIFF
--- a/Unix/installbuilder/datafiles/Linux.data
+++ b/Unix/installbuilder/datafiles/Linux.data
@@ -13,7 +13,8 @@ SERVICE_CTL:  '/opt/omi/bin/service_control'
 %Files
 /opt/omi/bin/support/installssllinks;         ../scripts/installssllinks;            755; root; ${{ROOT_GROUP_NAME}}
 /opt/omi/bin/support/omid.systemd;            ../installbuilder/service_scripts/omid.systemd; 644; root; ${{ROOT_GROUP_NAME}}
-/opt/omi/bin/support/omid;                    ../installbuilder/service_scripts/omid.ulinux; 755; root; ${{ROOT_GROUP_NAME}}
+/opt/omi/bin/support/omid.initd;              ../installbuilder/service_scripts/omid.ulinux; 755; root; ${{ROOT_GROUP_NAME}}
+/opt/omi/bin/support/omid.upstart;            ../installbuilder/service_scripts/omid.upstart; 755; root; ${{ROOT_GROUP_NAME}}
 /opt/omi/bin/service_control;                 ../installbuilder/service_scripts/service_control.linux; 755; root; ${{ROOT_GROUP_NAME}}
 
 %Directories
@@ -74,13 +75,19 @@ RemoveGenericService() {
         fi
     fi
 
+    if  [ -f /etc/init/${SERVICE}.conf ]; then
+        initctl stop omid
+    fi
+
     if [ -f /etc/init.d/${SERVICE} ]; then
-        if [ -x /usr/sbin/invoke-rc.d ]; then
-            /usr/sbin/invoke-rc.d ${SERVICE} stop
+        if [ -x /bin/systemctl ]; then
+            /bin/systemctl stop ${SERVICE}
         elif [ -x /sbin/service ]; then
             /sbin/service ${SERVICE} stop
-        elif [ -x /bin/systemctl ]; then
-            /bin/systemctl stop ${SERVICE}
+        elif [ -x /usr/sbin/service ]; then
+            /usr/sbin/service ${SERVICE} stop
+        elif [ -x /usr/sbin/invoke-rc.d ]; then
+            /usr/sbin/invoke-rc.d ${SERVICE} stop
         else
             echo "Unrecognized service controller to stop ${SERVICE} service" 1>&2
             exit 1
@@ -97,6 +104,12 @@ RemoveGenericService() {
         /bin/systemctl disable ${SERVICE}
         rm -f ${SYSTEMD_UNIT_DIR}/${SERVICE}.service
         /bin/systemctl daemon-reload
+    fi
+
+    if [ -f /etc/init/omid.conf ]; then
+        echo "Unconfiguring omid (upstart) service ..."
+        rm -f /usr/init/omid.conf
+        initctl reload-configuration
     fi
 
     if [ -f /etc/init.d/${SERVICE} ]; then
@@ -121,6 +134,7 @@ StopOmiService() {
 RemoveOmiService() {
     RemoveGenericService omid
     [ -f /etc/init.d/omid ] && rm /etc/init.d/omid
+    [ -f /etc/init/omid.conf ] && rm /etc/init/omid.conf
 }
 
 ConfigureOmiService() {
@@ -132,8 +146,14 @@ ConfigureOmiService() {
         cp /opt/omi/bin/support/omid.systemd ${SYSTEMD_UNIT_DIR}/omid.service
         /bin/systemctl daemon-reload
         /bin/systemctl enable omid
+    elif [ -d "/etc/init" ]; then
+        # If we have /etc/int, we have upstart
+        cp /opt/omi/bin/support/omid.upstart /etc/init/omid.conf
+
+        # initctl registers it with upstart
+        initctl reload-configuration
     else
-        cp /opt/omi/bin/support/omid /etc/init.d/omid
+        cp /opt/omi/bin/support/omid.initd /etc/init.d/omid
 
         if [ -x /usr/sbin/update-rc.d ]; then
             update-rc.d omid defaults > /dev/null

--- a/Unix/installbuilder/service_scripts/omid.upstart
+++ b/Unix/installbuilder/service_scripts/omid.upstart
@@ -1,0 +1,54 @@
+##
+## Copyright (c) Microsoft Corporation.  All rights reserved.
+##
+## Contains settings for the OMI WS-Management Deamon.
+##
+##
+#
+#### BEGIN INIT INFO
+## Provides:          omid
+## Required-Start:    $network
+## Required-Stop:     $network
+## Default-Start:     3 5
+## Default-Stop:      0 1 2 6
+## Short-Description: OMI Server
+## Description:       Microsoft Open Management Infrastructure (OMI) Server
+#### END INIT INFO
+#
+
+description	"Microsoft OMI Server"
+
+start on (starting network-interface
+      or starting networking)
+
+start on (stopping network-interface
+      or stoppng networking)
+
+console output
+
+expect daemon
+respawn
+respawn limit 10 30
+
+env OMI_BIN=/opt/omi/bin/omiserver
+env OMI_NAME="Microsoft OMI Server"
+env LOG_FILE=/var/opt/omi/log/omid.log
+
+pre-start script
+    exec >$LOG_FILE 2>&1
+    echo "Starting "$OMI_NAME
+    if [ ! -x $OMI_BIN ]; then
+        echo "$OMI_BIN not installed";
+        exit 5;
+    fi;
+end script
+
+post-stop script
+    exec >$LOG_FILE 2>&1
+    echo "Shutting down " $OMI_NAME
+    sleep 5  # sleeping makes sure we dont restart too fast 
+end script
+
+
+exec  $OMI_BIN --configfile=/etc/opt/omi/conf/omiserver.conf  -d
+

--- a/Unix/installbuilder/service_scripts/service_control.linux
+++ b/Unix/installbuilder/service_scripts/service_control.linux
@@ -76,12 +76,14 @@ start_omi()
     if pidof systemd 1> /dev/null 2> /dev/null; then
         /bin/systemctl start omid
     else
-        if [ -x /sbin/service ]; then
+        if [ -x /sbin/initctl ]; then
+            /sbin/initctl start omid 
+        elif [ -x /bin/systemctl ]; then
+            /bin/systemctl start omid
+        elif [ -x /sbin/service ]; then
             /sbin/service omid start
         elif [ -x /usr/sbin/service ]; then
             /usr/sbin/service omid start
-        elif [ -x /bin/systemctl ]; then
-            /bin/systemctl start omid
         elif [ -x /usr/sbin/invoke-rc.d ]; then
             /usr/sbin/invoke-rc.d omid start
         else
@@ -99,12 +101,14 @@ stop_omi()
         if pidof systemd 1> /dev/null 2> /dev/null; then
             /bin/systemctl stop omid
         else
-            if [ -x /sbin/service ]; then
+            if [ -x /sbin/initctl ]; then
+                /sbin/initctl stop omid 
+            elif [ -x /bin/systemctl ]; then
+                /bin/systemctl stop omid
+            elif [ -x /sbin/service ]; then
                 /sbin/service omid stop
             elif [ -x /usr/sbin/service ]; then
                 /usr/sbin/service omid stop
-            elif [ -x /bin/systemctl ]; then
-                /bin/systemctl stop omid
             elif [ -x /usr/sbin/invoke-rc.d ]; then
                 /usr/sbin/invoke-rc.d omid stop
             else
@@ -127,7 +131,11 @@ restart_omi()
     if pidof systemd 1> /dev/null 2> /dev/null; then
         /bin/systemctl restart omid
     else
-        if [ -x /sbin/service ]; then
+        if [ -x /sbin/initctl ]; then
+            /sbin/initctl restart omid 
+        elif [ -x /bin/systemctl ]; then
+            /bin/systemctl restart omid
+        elif [ -x /sbin/service ]; then
             /sbin/service omid restart
         elif [ -x /usr/sbin/service ]; then
             /usr/sbin/service omid restart


### PR DESCRIPTION
@Microsoft/omi-devs  
Implements omi daemon handling via upstart, which is supported on ubuntu 14 and centos 6. This allows the upstart daemon to automatically restart the omi server on failure. 

This implements the enhancement requested in issue 267