### PR TITLE
Fix seg fault on some platforms

### DIFF
--- a/Unix/protocol/protocol.c
+++ b/Unix/protocol/protocol.c
@@ -1307,8 +1307,6 @@ static MI_Boolean _RequestCallback(
         trace_RequestCallback_Connect_RemovingHandler( handler, mask, handler->base.mask );
 
         _ProtocolSocket_Cleanup(handler);
-
-        ProtocolSocket_Release(handler);
     }
 
     return MI_TRUE;


### PR DESCRIPTION
It was observed on pbuild of osdev64-cent5-01 and osd64-sls10-01 that seg fault happens during omiserver shutdown.

Investigations show that during shutdown, when Selector_RemoveAllHandlers() is called, a sequence of _ProtocolSocket_* functions are invoked:

_ProtocolSocket_Cleanup()
_ProtocolSocket_Close()
_ProtocolSocket_Finish()
_ProtocolSocket_Release()

Since both _ProtocolSocket_Finish() and _ProtocolSocket_Release() frees the allocated memory, one shouldn't call both.  The fix for now is to remove the _ProtocolSocket_Release() line.
