### PR TITLE
Add support for OMI to work with OpenSSL v1.1.*

### DIFF
--- a/Unix/configure
+++ b/Unix/configure
@@ -469,16 +469,19 @@ fi
 if [ "$enable_ulinux" = "1" ]; then
     openssl098_dir=/usr/local_ssl_0.9.8
     openssl100_dir=/usr/local_ssl_1.0.0
+    openssl110_dir=/usr/local_ssl_1.1.0
 
     case "`uname -m`" in    
         x86_64 )
             openssl098_libdir=${openssl098_dir}/lib
             openssl100_libdir=${openssl100_dir}/lib64
+            openssl110_libdir=${openssl110_dir}/lib
             ;;
         
         * )
             openssl098_libdir=${openssl098_dir}/lib
             openssl100_libdir=${openssl100_dir}/lib
+            openssl110_libdir=${openssl110_dir}/lib
             ;;
     esac
 
@@ -486,6 +489,8 @@ if [ "$enable_ulinux" = "1" ]; then
     openssl098_libs=`PKG_CONFIG_PATH=$openssl098_libdir/pkgconfig $pkgconfig --libs openssl`
     openssl100_cflags=`PKG_CONFIG_PATH=$openssl100_libdir/pkgconfig $pkgconfig --cflags openssl`
     openssl100_libs=`PKG_CONFIG_PATH=$openssl100_libdir/pkgconfig $pkgconfig --libs openssl`
+    openssl110_cflags=`PKG_CONFIG_PATH=$openssl110_libdir/pkgconfig $pkgconfig --cflags openssl`
+    openssl110_libs=`PKG_CONFIG_PATH=$openssl110_libdir/pkgconfig $pkgconfig --libs openssl`
 
     if [ "$disable_ssl_0_9_8" != "1" ]; then
         echo "checking for local installation of openssl version 0.9.8 on system ..."
@@ -500,6 +505,13 @@ if [ "$enable_ulinux" = "1" ]; then
     if [ ! -d "$openssl100_dir" ]; then
         echo "did not find ${openssl100_dir}, which is required."
         echo "You must install a local copy of OpenSSL version 1.0.0 to build successfully."
+        exit 1
+    fi
+
+    echo "checking for local installation of openssl version 1.1.0 on system ..."
+    if [ ! -d "$openssl110_dir" ]; then
+        echo "did not find ${openssl110_dir}, which is required."
+        echo "You must install a local copy of OpenSSL version 1.1.0 to build successfully."
         exit 1
     fi
 fi
@@ -2492,6 +2504,12 @@ endif
 	echo Running: ./configure \$(OMI_CONFIGURE_QUALS) --outputdirname=output_openssl_1.0.0 --opensslcflags="${openssl100_cflags}" --openssllibs="${openssl100_libs}" --openssllibdir="${openssl100_libdir}"; \
 	./configure \$(OMI_CONFIGURE_QUALS) --outputdirname=output_openssl_1.0.0 --opensslcflags="${openssl100_cflags}" --openssllibs="${openssl100_libs}" --openssllibdir="${openssl100_libdir}"; \
 	( cd \$(__ROOT); OUTPUTDIR=${root}/output_openssl_1.0.0; \$(MAKE) -f build.mak )
+
+	@echo '========================= Performing Building OMI (SSL 1.1.0)'
+
+	echo Running: ./configure \$(OMI_CONFIGURE_QUALS) --outputdirname=output_openssl_1.1.0 --opensslcflags="${openssl110_cflags}" --openssllibs="${openssl110_libs}" --openssllibdir="${openssl110_libdir}"; \
+	./configure \$(OMI_CONFIGURE_QUALS) --outputdirname=output_openssl_1.1.0 --opensslcflags="${openssl110_cflags}" --openssllibs="${openssl110_libs}" --openssllibdir="${openssl110_libdir}"; \
+	( cd \$(__ROOT); OUTPUTDIR=${root}/output_openssl_1.1.0; \$(MAKE) -f build.mak )
 
 else
 

--- a/Unix/configure
+++ b/Unix/configure
@@ -301,6 +301,11 @@ do
         if  [ "`uname -s`" = "Linux" -a "`uname -m`" != "ppc64le" ]; then
             enable_ulinux=1
         fi
+
+	if [ `uname -m` != "x86_64" ]; then
+	    echo "Note: Will NOT build for OpenSSL 1.1.0 on 32-bit platforms ..."
+            disable_ssl_1_1_0=1
+	fi
         ;;
 
     --disable-makefile-gen)
@@ -481,7 +486,7 @@ if [ "$enable_ulinux" = "1" ]; then
         * )
             openssl098_libdir=${openssl098_dir}/lib
             openssl100_libdir=${openssl100_dir}/lib
-            openssl110_libdir=${openssl110_dir}/lib
+            [ `uname -m` = "x86_64" ] && openssl110_libdir=${openssl110_dir}/lib
             ;;
     esac
 
@@ -489,8 +494,11 @@ if [ "$enable_ulinux" = "1" ]; then
     openssl098_libs=`PKG_CONFIG_PATH=$openssl098_libdir/pkgconfig $pkgconfig --libs openssl`
     openssl100_cflags=`PKG_CONFIG_PATH=$openssl100_libdir/pkgconfig $pkgconfig --cflags openssl`
     openssl100_libs=`PKG_CONFIG_PATH=$openssl100_libdir/pkgconfig $pkgconfig --libs openssl`
-    openssl110_cflags=`PKG_CONFIG_PATH=$openssl110_libdir/pkgconfig $pkgconfig --cflags openssl`
-    openssl110_libs=`PKG_CONFIG_PATH=$openssl110_libdir/pkgconfig $pkgconfig --libs openssl`
+
+    if [ `uname -m` = "x86_64" ]; then
+	openssl110_cflags=`PKG_CONFIG_PATH=$openssl110_libdir/pkgconfig $pkgconfig --cflags openssl`
+	openssl110_libs=`PKG_CONFIG_PATH=$openssl110_libdir/pkgconfig $pkgconfig --libs openssl`
+    fi
 
     if [ "$disable_ssl_0_9_8" != "1" ]; then
         echo "checking for local installation of openssl version 0.9.8 on system ..."
@@ -509,7 +517,7 @@ if [ "$enable_ulinux" = "1" ]; then
     fi
 
     echo "checking for local installation of openssl version 1.1.0 on system ..."
-    if [ ! -d "$openssl110_dir" ]; then
+    if [ `uname -m` = "x86_64" -a ! -d "$openssl110_dir" ]; then
         echo "did not find ${openssl110_dir}, which is required."
         echo "You must install a local copy of OpenSSL version 1.1.0 to build successfully."
         exit 1
@@ -2481,6 +2489,7 @@ export ROOT=$root
 export ENABLE_ULINUX=$enable_ulinux
 export ENABLE_NATIVE_KITS=$enable_native_kits
 export DISABLE_SSL_0_9_8=$disable_ssl_0_9_8
+export DISABLE_SSL_1_1_0=$disable_ssl_1_1_0
 
 OMI_CONFIGURE_QUALS=--enable-microsoft --disable-makefile-gen
 ifeq (\$(ENABLE_NATIVE_KITS),1)
@@ -2505,11 +2514,13 @@ endif
 	./configure \$(OMI_CONFIGURE_QUALS) --outputdirname=output_openssl_1.0.0 --opensslcflags="${openssl100_cflags}" --openssllibs="${openssl100_libs}" --openssllibdir="${openssl100_libdir}"; \
 	( cd \$(__ROOT); OUTPUTDIR=${root}/output_openssl_1.0.0; \$(MAKE) -f build.mak )
 
+ifneq (\$(DISABLE_SSL_1_1_0),1)
 	@echo '========================= Performing Building OMI (SSL 1.1.0)'
 
 	echo Running: ./configure \$(OMI_CONFIGURE_QUALS) --outputdirname=output_openssl_1.1.0 --opensslcflags="${openssl110_cflags}" --openssllibs="${openssl110_libs}" --openssllibdir="${openssl110_libdir}"; \
 	./configure \$(OMI_CONFIGURE_QUALS) --outputdirname=output_openssl_1.1.0 --opensslcflags="${openssl110_cflags}" --openssllibs="${openssl110_libs}" --openssllibdir="${openssl110_libdir}"; \
 	( cd \$(__ROOT); OUTPUTDIR=${root}/output_openssl_1.1.0; \$(MAKE) -f build.mak )
+endif
 
 else
 

--- a/Unix/installbuilder/GNUmakefile
+++ b/Unix/installbuilder/GNUmakefile
@@ -6,16 +6,18 @@ include $(TOP)/config.mak
 #    output
 #    output_openssl_0.9.8
 #    output_openssl_1.0.0
+#    output_openssl_1.1.0
 #
 # Get this into some reasonable prefix for the package directory.
 #
 #    omi/Packages - good for only one set of packages
 #    omi/Packages/openssl_0.9.8 - good for binaries for OpenSSL 0.9.8
 #    omi/Packages/openssl_1.0.0 - good for binaries for OpenSSL 1.0.0
+#    omi/Packages/openssl_1.1.0 - good for binaries for OpenSSL 1.1.0
 #
 # This makes it easier for Jenkins to have a reasonable directory layout
 PACKAGE_DIR_SUFFIX = $(shell echo $(OUTPUTDIRNAME) | sed 's/output//' | sed 's~^_open~/open~')
-PACKAGE_SSL_DECORATION = $(shell echo $(OUTPUTDIRNAME) | sed 's/output_openssl_0.9.8/ssl_098/' | sed 's/output_openssl_1.0.0/ssl_100/')
+PACKAGE_SSL_DECORATION = $(shell echo $(OUTPUTDIRNAME) | sed 's/output_openssl_0.9.8/ssl_098/' | sed 's/output_openssl_1.0.0/ssl_100/' | sed 's/output_openssl_1.1.0/ssl_110/')
 PACKAGE_DIR = $(TOP)/../Packages/$(BUILD_CONFIGURATION)$(PACKAGE_DIR_SUFFIX)
 
 DISTRO_TYPE = $(PF)

--- a/Unix/scripts/installssllinks
+++ b/Unix/scripts/installssllinks
@@ -12,8 +12,13 @@ verify_ssl_version() {
             LIB_SUFFIX="1.0.0"
             ATTEMPT_HMAC_LINK_CREATION=1
             ;;
+        1.1.*)
+            LIB_SUFFIX="1.1.0"
+            ATTEMPT_HMAC_LINK_CREATION=1
+            ;;
         *)
-            echo "Error: OpenSSL version '${SSL_VERSION}' is not supported. Only OpenSSL versions 0.9.8* and 1.0.* are supported." >&2
+            echo "Error: OpenSSL version '${SSL_VERSION}' is not supported. Supported versions of OpenSSL are:" >&2
+            echo "    0.9.8*, 1.0.*, and 1.1.*." >&2
             exit 2
             ;;
     esac


### PR DESCRIPTION
@ostc-devs @Microsoft/omi-devs 

A variety of changes were needed here:

1. Modify build system to build against OpenSSL v1.1.0,
2. Modify OMI (specifically `base/credcache.c`) to build with both old and new versions of OpenSSL,
3. Modify linkages (at run time) to recognize and link against OpenSSL v1.1.*.

For testing, I built on a universal build system to generate the `omi-1.3.0-33.ssl_110.ulinux.x64.deb` package. Debian 9 is currently the only system shipping with OpenSSL v1.1 by default, so I installed Debian 9 in a local VM, installed the omi package there, and verified that the identity provider ran properly.