### PR TITLE
Eliminate failure on rh7.3 ppc

### DIFF
--- a/Unix/http/http.c
+++ b/Unix/http/http.c
@@ -1560,7 +1560,6 @@ static MI_Boolean _ListenerCallback(
         (mask & SELECTOR_DESTROY) != 0)
     {
         trace_SocketClose_REMOVEDESTROY();
-        HttpAuth_Close(handler_);
         Sock_Close(handler->base.sock);
         PAL_Free(handler);
     }

--- a/Unix/http/httpauth.c
+++ b/Unix/http/httpauth.c
@@ -2045,6 +2045,7 @@ void HttpAuth_Close(_In_ Handler *handlerIn)
 
    if (_g_gssState.Gss_Delete_Sec_Context && handlerIn && context_hdl) 
    {
+       handler->pAuthContext = NULL;
        (*_g_gssState.Gss_Delete_Sec_Context)(&min_stat, &context_hdl, NULL);
    }
 }


### PR DESCRIPTION
There was a cross thread double free when we also had _ListenerCallback delete the context. This only showed up intermittently on the RH 7.3 PPC machine, and not on any others, but it appears to have been real. 
@Microsoft/omi-devs 