### PR TITLE
Fix memory leak for gss_acquire_cred()

### DIFF
--- a/Unix/http/httpauth.c
+++ b/Unix/http/httpauth.c
@@ -2154,10 +2154,19 @@ void HttpAuth_Close(_In_ Handler *handlerIn)
    gss_ctx_id_t context_hdl = handler->pAuthContext;
    OM_uint32 min_stat = 0;
 
-   if (_g_gssState.Gss_Delete_Sec_Context && handlerIn && context_hdl) 
+   if(handlerIn)
    {
-       handler->pAuthContext = NULL;
-       (*_g_gssState.Gss_Delete_Sec_Context)(&min_stat, &context_hdl, NULL);
+       if (_g_gssState.Gss_Release_Cred && handler->pVerifierCred )
+       {
+             (*_g_gssState.Gss_Release_Cred)(&min_stat, handler->pVerifierCred);
+             handler->pVerifierCred = NULL;
+       }
+
+       if (_g_gssState.Gss_Delete_Sec_Context && context_hdl) 
+       {
+           handler->pAuthContext = NULL;
+           (*_g_gssState.Gss_Delete_Sec_Context)(&min_stat, &context_hdl, NULL);
+       }
    }
 }
 


### PR DESCRIPTION
@Microsoft/omi-devs  I have fixed the memory fix for gss_acquire_cred() and I have verified the fix works, the memory of omiengine process keep on 1.0% from top command while running 10000 queries per second, could you help to review this PR? thanks very much!

This is the memory fix for previous release '1.3.0-2' omi version.

10000 queries per second command:
```
for i in {1..10000}; do /opt/omi/bin/omicli ei -u scxuser -p scxuserpasswd --auth NegoWithCreds --hostname omi64-cent7-05 --port 5985 --encryption none root/cimv2 TestClass_AllDMTFArrays;sleep 1; done
```