### PR TITLE
Add omi.keytab update to the installer

### DIFF
--- a/Unix/installbuilder/datafiles/Base_OMI.data
+++ b/Unix/installbuilder/datafiles/Base_OMI.data
@@ -27,7 +27,7 @@ PAM_CONF_DIR: '/etc/pam.d'
 /opt/omi/bin/omireg;                          bin/omireg;                            755; root; ${{ROOT_GROUP_NAME}}
 /opt/omi/bin/omigen;                          bin/omigen;                            755; root; ${{ROOT_GROUP_NAME}}
 /opt/omi/bin/omiconfigeditor;                 bin/omiconfigeditor;                   755; root; ${{ROOT_GROUP_NAME}}
-/opt/omi/lib/libmi.${{SHLIB_EXT}};            lib/libmi.${{SHLIB_EXT}};           755; root; ${{ROOT_GROUP_NAME}}
+/opt/omi/lib/libmi.${{SHLIB_EXT}};            lib/libmi.${{SHLIB_EXT}};              755; root; ${{ROOT_GROUP_NAME}}
 /opt/omi/lib/libmicxx.${{SHLIB_EXT}};         lib/libmicxx.${{SHLIB_EXT}};           755; root; ${{ROOT_GROUP_NAME}}
 /opt/omi/lib/libomiclient.${{SHLIB_EXT}};     lib/libomiclient.${{SHLIB_EXT}};       755; root; ${{ROOT_GROUP_NAME}}
 /opt/omi/lib/libomiidentify.${{SHLIB_EXT}};   lib/libomiidentify.${{SHLIB_EXT}};     755; root; ${{ROOT_GROUP_NAME}}
@@ -40,11 +40,13 @@ PAM_CONF_DIR: '/etc/pam.d'
 /opt;                                    755; root; ${{ROOT_GROUP_NAME}}; sysdir
 /opt/omi;                                755; root; ${{ROOT_GROUP_NAME}}
 /opt/omi/bin;                            755; root; ${{ROOT_GROUP_NAME}}
+/opt/omi/bin/support;                    755; root; ${{ROOT_GROUP_NAME}}
 /etc/opt;                                755; root; ${{ROOT_GROUP_NAME}}; sysdir
 /etc/opt/omi;                            755; root; ${{ROOT_GROUP_NAME}}
 /etc/opt/omi/conf;                       755; root; ${{ROOT_GROUP_NAME}}
 /etc/opt/omi/conf/omiregister/root-omi;  755; root; ${{ROOT_GROUP_NAME}}
 /etc/opt/omi/ssl;                        755; root; ${{ROOT_GROUP_NAME}}
+/etc/opt/omi/creds;                      755; root; ${{ROOT_GROUP_NAME}}
 /var/opt;                                755; root; ${{ROOT_GROUP_NAME}}; sysdir
 /var/opt/omi;                            755; root; ${{ROOT_GROUP_NAME}}
 /var/opt/omi/log;                        755; root; ${{ROOT_GROUP_NAME}}
@@ -520,6 +522,8 @@ ConfigurePAM
 chown omi:omi /var/opt/omi/log
 chown omi:omi /var/opt/omi/run
 chown omi:omi /etc/opt/omi/ssl/omikey.pem
+chown omi:omi /etc/opt/omi/creds
+chmod 500 /etc/opt/omi/creds
 
 # Fix potential permissons issue on /etc/opt/omi directory
 chown root:${{ROOT_GROUP_NAME}} /etc/opt/omi

--- a/Unix/installbuilder/datafiles/Linux.data
+++ b/Unix/installbuilder/datafiles/Linux.data
@@ -11,14 +11,15 @@ PF:           'Linux'
 SERVICE_CTL:  '/opt/omi/bin/service_control'
 
 %Files
-/opt/omi/bin/support/installssllinks;         ../scripts/installssllinks;            755; root; ${{ROOT_GROUP_NAME}}
-/opt/omi/bin/support/omid.systemd;            ../installbuilder/service_scripts/omid.systemd; 644; root; ${{ROOT_GROUP_NAME}}
-/opt/omi/bin/support/omid.initd;              ../installbuilder/service_scripts/omid.ulinux; 755; root; ${{ROOT_GROUP_NAME}}
-/opt/omi/bin/support/omid.upstart;            ../installbuilder/service_scripts/omid.upstart; 755; root; ${{ROOT_GROUP_NAME}}
+/opt/omi/bin/support/installssllinks;         ../scripts/installssllinks;                              755; root; ${{ROOT_GROUP_NAME}}
+/opt/omi/bin/support/omid.systemd;            ../installbuilder/service_scripts/omid.systemd;          644; root; ${{ROOT_GROUP_NAME}}
+/opt/omi/bin/support/omid.initd;              ../installbuilder/service_scripts/omid.ulinux;           755; root; ${{ROOT_GROUP_NAME}}
+/opt/omi/bin/support/omid.upstart;            ../installbuilder/service_scripts/omid.upstart;          755; root; ${{ROOT_GROUP_NAME}}
 /opt/omi/bin/service_control;                 ../installbuilder/service_scripts/service_control.linux; 755; root; ${{ROOT_GROUP_NAME}}
+/opt/omi/bin/support/ktstrip;                 ../tools/ktstrip;                                        755; root; ${{ROOT_GROUP_NAME}}
+/opt/omi/bin/support/config_keytab_update.sh; ../scripts/config_keytab_update.sh;                      755; root; ${{ROOT_GROUP_NAME}}
 
 %Directories
-/opt/omi/bin/support;                    755; root; ${{ROOT_GROUP_NAME}}
 /opt/omi/lib;                            775; root; omiusers
 /etc/opt/omi/conf/omiregister;           775; root; omiusers
 /var/opt/omi/omiusers;                   775; root; omiusers
@@ -195,10 +196,19 @@ fi
 chgrp omiusers /opt/omi/lib /etc/opt/omi/conf/omiregister /var/opt/omi/omiusers
 chmod 775 /opt/omi/lib /etc/opt/omi/conf/omiregister /var/opt/omi/omiusers
 
+chmod 500 /opt/omi/bin/support/ktstrip
+chmod 500 /opt/omi/bin/support/config_keytab_update.sh
+
+
 # Be certain that SSL linkages exist for OMI utilities
 /opt/omi/bin/support/installssllinks
 
+# Set up the cron job to update the omi.keytab
+/opt/omi/bin/support/config_keytab_update.sh --configure
+
 ConfigureOmiService
+
+
 
 %Preuninstall_10
 #include OmiService_funcs
@@ -206,6 +216,7 @@ ConfigureOmiService
 # If we're called for upgrade, don't do anything
 if ${{PERFORMING_UPGRADE_NOT}}; then
     RemoveOmiService
+    /opt/omi/bin/support/config_keytab_update.sh --unconfigure
 fi
 
 %Postuninstall_100

--- a/Unix/scripts/config_keytab_update.sh
+++ b/Unix/scripts/config_keytab_update.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+#
+# usage: update_keytab.sh
+
+SCRIPTNAME=$0
+OMI_HOME=/opt/omi
+
+syskeytab="/etc/krb5.keytab"
+omikeytab="/etc/opt/omi/creds/omi.keytab"
+ktstrip="$OMI_HOME/bin/support/ktstrip"
+tmpfile=$(mktemp)
+
+checkConfiguration()
+{
+    if ! crontab -l 2> /dev/null | grep -q "$ktstrip" ; then
+        return 1
+    fi
+
+    return 0
+}
+
+
+configure()
+{
+    if checkConfiguration; then
+       timestamp=$(date +%F\ %T)
+       printf $timestamp "System already configured to run $SCRIPTNAME automatically"
+       return 0
+    fi
+
+    # prime the omi keytab
+    $ktstrip $syskeytab $omikeytab
+
+    crontab -l > $tmpfile 2> /dev/null || true
+
+    # We don't worry about log rotate
+    # execute the check every minute.
+
+    echo "* * * * * [ $syskeytab -nt $omikeytab ] && $ktstrip $syskeytab $omikeytab" >>$tmpfile
+
+    crontab $tmpfile
+
+    timestamp=$(date +%F\ %T)
+    printf $timestamp ": Crontab configured to update omi keytab automatically"
+}
+
+unconfigure()
+{
+    if ! checkConfiguration; then
+        timestamp=$(date +%F\ %T)
+        printf $timestamp ": Crontab not configured to update omi keytab automatically. Skip unconfigure"
+        return 0
+    fi
+
+    crontab -l > $tmpfile 2> /dev/null || true
+
+    egrep -v "$omikeytab" $tmpfile | crontab
+
+    timestamp=$(date +%F\ %T)
+    printf $timestamp ": Crontab no longer configured to update omi keytab."
+}
+
+
+
+while [ $# -ne 0 ]
+do
+    case "$1" in
+	--configure)
+        configure
+	    shift 1
+	    ;;
+
+	--unconfigure)
+        unconfigure
+	    shift 1
+	    ;;
+
+    *)
+        printf "$0 unknown option"
+        numargs=0
+        ;;
+    esac
+done
+

--- a/Unix/tools/ktstrip
+++ b/Unix/tools/ktstrip
@@ -1,29 +1,30 @@
-#!/bin/bash
+#!/bin/sh
 #
-# Usage: ktstrip <src_kt> <dst_kt> <user:group>
+# Usage: ktstrip <src_kt> <dst_kt> [user:group]
 #
 
 user=$3
+if [ "$user" =  "" ]
+then
+user="omi:omi"
+fi
 
 SRC_KT=$(readlink -f $1)
-rc=$?
-if  [[ $rc -ne 0 ]]
+if  [ !? -ne 0 ]
 then
    echo "File  " $1 " could not be read" 2>&1
    exit -1
 fi
 
 DST_KT=$(readlink -f $2)
-rc=$?
-if  [[ $rc -ne 0 ]]
+if  [ $? -ne 0 ]
 then
    echo "directory  " $2 " could not be read" 2>&1
    exit -1
 fi
 
 dst_dir=$(dirname $2)
-rc=$?
-if  [[ $rc -ne 0 ]]
+if  [ $? -ne 0 ]
 then
    echo "directory  " $dst_dir " could not be read" 2>&1
    exit -1
@@ -43,59 +44,39 @@ then
    exit -2
 fi
 
-TMP_FILE=$(mktemp)
-list=$(printf "read_kt $SRC_KT\nlist\n" | ktutil | awk '/[0-9]/ { print " "$1"|" $2"|"$3 }' )
-
-declare -a remove_entries=()
-for princ in $list
-do
-    IFS='|' read -r -a principal <<< "$princ"
-#    echo "Principal " "${principal[2]}"
-    principalname="${principal[2]}"
-    entryno="${principal[0]}"
-    keyvers="${principal[1]}"
-    
-    case $principalname in
-       host/*) printf  $principalname"\n" ;;
-       RestrictedKrbHost/*) printf $principalname"\n" ;;
-       *) printf "remove " $principalname "\n" 
-
-          remove_entries+=($entryno)
-          ;;
-    esac
-done
-
-
-
-echo "remove entries " "${remove_entries[@]}"
-
-declare -a delcmd=()
-
-printf "read_kt $SRC_KT \n" >$TMP_FILE
+list=$(mktemp)
+delete_list=$(mktemp)
+cmd=$(mktemp)
+tmp_kt="/tmp/tmp.kt"
 
 #
-# The lines must be from largest forward or else when each entry is deleted, the following entry numbers will change.
+# Use ktutil to strip the soure keytab of anything but host/ and RestrictedKrbHost/ principals
+# First, get a list of principals and put it in a temp file to retain its line structure. 
+# This will have junk on top that we need to strip off, including the read_kt and list commands and the 
+# table of keys header lines
+printf "read_kt $SRC_KT\nlist\n" | ktutil >$list  
+
 #
+# Take the list. The first awk selects only the lines that start with some nomber of spaces and a digit. This gest rid of the 
+# junk so every line has a keytab slot descrtiptor.
+# The next awk generates a delete_entry command for each unwanted slot.
+# We then sort to reverse the list since each time you delete an entry the entries after get new slot numbers.
+# sort -rV reverse sorts the entries by "version number" which is to say actual numeric value. -n sorts by digit.
+cat $list | awk '/^[ ]*[0-9]/{ print " "$1" " $2" "$3 }' | awk '{ if ( $3 !~ /host\/|RestrictedKrbHost\// ) { print "delete_entry " $1; } }' | sort -rV  >$delete_list
 
-i=${#remove_entries[*]}
-i=$((i-1))
-while [ $i -ge 0 ]
-do
-   val=${remove_entries[$i]}
-   printf "delete_entry $val\n" >>$TMP_FILE
-   i=$((i-1))
-done
+# Build the final command file adding commands at the front and back
+printf "read_kt $SRC_KT \n" | cat - $delete_list >$cmd
+printf "write_kt $tmp_kt\n"   >>$cmd
 
-rm /tmp/t.kt
+# The command file will now ready to delete all unneeded entries.
+printf "Creating $DST_KT\n"
+cat $cmd | ktutil
+printf "Move $tmp_kt to $DST_KT\n"
+mv $tmp_kt $DST_KT
 
-printf "write_kt /tmp/t.kt\n" >>$TMP_FILE
-
-cat $TMP_FILE | ktutil
-mv /tmp/t.kt $DST_KT
-
+# and we adjust the ownership of the keytab so the omi user can see it.
 chown $user $DST_KT
-rc=$?
-if  [[ $rc -ne 0 ]]
+if  [ $? -ne 0 ]
 then
    echo "could not set user  " $user  " as owner of $DST_KT" 2>&1
    exit -1


### PR DESCRIPTION
The scripts are placed on all systems as we probably can support these systems using kerberos. We just haven't tested it. 

The cronjob to update is only started/stopped on Linux. 