### PR TITLE
Added features to support the OMI-Script-Provider.

### DIFF
--- a/Unix/agent/agent.c
+++ b/Unix/agent/agent.c
@@ -164,16 +164,12 @@ static void _RequestCallback(
     else
     {
         MI_Result result;
-        ProvRegEntry regentry;
         RequestMsg* request = (RequestMsg*)interactionParams->msg;
 
         DEBUG_ASSERT( Message_IsRequest(interactionParams->msg) );
 
-        memset(&regentry, 0, sizeof(regentry));
-        regentry.libraryName = request->libraryName;
-        regentry.instanceLifetimeContext = request->instanceLifetimeContext;
-
-        result = ProvMgr_NewRequest(&s_data.provmgr, &regentry, interactionParams );
+        result = ProvMgr_NewRequest(
+            &s_data.provmgr, &(request->regEntry), interactionParams );
 
         if (MI_RESULT_OK != result)
         {

--- a/Unix/base/getopt.c
+++ b/Unix/base/getopt.c
@@ -79,13 +79,18 @@ int GetOpt(
                 hasArg = 1;
                 opt[n-1] = '\0';
             }
+            else if (opt[n-1] == '?')
+            {
+                hasArg = 2;
+                opt[n-1] = '\0';
+            }
             else
                 hasArg = 0;
 
             /* Does argv[i] match this option? */
             if (strcmp(argv[i], opt) == 0)
             {
-                if (hasArg)
+                if (hasArg == 1)
                 {
                     if (i + 1 == *argc)
                     {

--- a/Unix/base/messages.c
+++ b/Unix/base/messages.c
@@ -64,7 +64,15 @@ static const MessageField emptyMessageFields[] =
 
 static const MessageField requestMessageFields[] =
 {
-    {MFT_POINTER_OPT,offsetof(RequestMsg, libraryName),0,0},
+    {MFT_POINTER_OPT,offsetof(RequestMsg, regEntry.user),0,0},
+    {MFT_POINTER_OPT,offsetof(RequestMsg, regEntry.nameSpace),0,0},
+    {MFT_POINTER_OPT,offsetof(RequestMsg, regEntry.className),0,0},
+    {MFT_POINTER_OPT,offsetof(RequestMsg, regEntry.libraryName),0,0},
+    {MFT_POINTER_OPT,offsetof(RequestMsg, regEntry.interpreter),0,0},
+    {MFT_POINTER_OPT,offsetof(RequestMsg, regEntry.startup),0,0},
+#if defined(CONFIG_ENABLE_PREEXEC)
+    {MFT_POINTER_OPT,offsetof(RequestMsg, regEntry.preexec),0,0},
+#endif
     {MFT_INSTANCE_OPT,offsetof(RequestMsg, options),offsetof(RequestMsg, packedOptionsPtr),offsetof(RequestMsg, packedOptionsSize)},
     {MFT_END_OF_LIST, 0, 0, 0}
 };

--- a/Unix/base/messages.h
+++ b/Unix/base/messages.h
@@ -19,6 +19,7 @@
 #include <pal/atomic.h>
 #include "user.h"
 #include <pal/thread.h>
+#include <provreg/provreg.h>
 
 BEGIN_EXTERNC
 
@@ -279,8 +280,7 @@ typedef struct _RequestMsg
     /* Name of HTTP user agent */
     MI_Uint32       userAgent;
     /* Server -> agent IPC specific */
-    const char *libraryName;
-    MI_Boolean instanceLifetimeContext;
+    ProvRegEntry regEntry;
     /*
     ** Options used by these methods:
     **     MI_Context_GetStringOption()

--- a/Unix/configure
+++ b/Unix/configure
@@ -1704,6 +1704,7 @@ if [ "$dev" = "1" ]; then
     sudo cp -p $rootrelative/etc/omiserver.conf $fn
     sudo cp -p $rootrelative/etc/omicli.conf $fn
     sudo cp -p $rootrelative/etc/omigen.conf $fn
+    sudo cp -p $rootrelative/etc/omireg.conf $fn
     sudo cp -rp $rootrelative/etc/omiregister $fn
 
     if [ -f $fn/omiserver.conf ]; then
@@ -1722,6 +1723,7 @@ if [ "$dev" = "1" ]; then
 
     test -f $fn/omicli.conf && echo "created $fn/omicli.conf"
     test -f $fn/omigen.conf && echo "created $fn/omigen.conf"
+    test -f $fn/omireg.conf && echo "created $fn/omireg.conf"
     test -d $fn/omiregister && echo "created $fn/omiregister"
 fi
 
@@ -2323,6 +2325,11 @@ fi
 if test ! -f "\$destdir/$sysconfdir/omigen.conf"
 then 
     cp $rootrelative/etc/omigen.conf \$destdir/$sysconfdir/omigen.conf
+fi
+
+if test ! -f "\$destdir/$sysconfdir/omireg.conf"
+then 
+    cp $rootrelative/etc/omireg.conf \$destdir/$sysconfdir/omireg.conf
 fi
 
 ##

--- a/Unix/disp/agentmgr.c
+++ b/Unix/disp/agentmgr.c
@@ -1177,10 +1177,9 @@ static MI_Result _SendRequestToAgent_Common(
         DEBUG_ASSERT( Message_IsRequest(req) );
         {
             RequestMsg* request = (RequestMsg*)req;
-            request->libraryName = Batch_Strdup(req->batch, proventry->libraryName);
-            request->instanceLifetimeContext = proventry->instanceLifetimeContext;
 
-            if (!request->libraryName)
+            if (MI_RESULT_OK != ProvRegEntry_Clone(
+                    req->batch, proventry, &(request->regEntry)))
             {
                 trace_SendRequestToAgent_Batch_Strdup_Failed();
                 StrandEntry_DeleteNoAdded( &requestItem->strand );

--- a/Unix/etc/omireg.conf
+++ b/Unix/etc/omireg.conf
@@ -1,0 +1,5 @@
+# omireg configuration file
+
+##
+## script = Tag:Interpreter:Startup
+##

--- a/Unix/installbuilder/datafiles/Base_OMI.data
+++ b/Unix/installbuilder/datafiles/Base_OMI.data
@@ -34,6 +34,7 @@ PAM_CONF_DIR: '/etc/pam.d'
 /etc/opt/omi/conf/omicli.conf;                ../etc/omicli.conf;                    444; root; sys
 /etc/opt/omi/conf/omiserver.conf;             ../installbuilder/conf/omiserver.conf; 444; root; sys; conffile
 /etc/opt/omi/conf/omigen.conf;                ../etc/omigen.conf;                    444; root; sys
+/etc/opt/omi/conf/omireg.conf;                ../etc/omireg.conf;                    444; root; sys
 /etc/opt/omi/conf/omiregister/root-omi/omiidentify.reg; ../etc/omiregister/root-omi/omiidentify.reg; 755; root; ${{ROOT_GROUP_NAME}}
 
 %Directories

--- a/Unix/omireg/omireg.cpp
+++ b/Unix/omireg/omireg.cpp
@@ -10,6 +10,7 @@
 #include <common.h>
 #include <string>
 #include <vector>
+#include <map>
 #include <pal/shlib.h>
 #ifndef _MSC_VER
 #include <unistd.h>
@@ -21,6 +22,8 @@
 #include <pal/file.h>
 #include <pal/sleep.h>
 #include <base/naming.h>
+#include <base/env.h>
+#include <base/conf.h>
 #ifndef _MSC_VER
 #include <dlfcn.h>
 #include <sys/wait.h>
@@ -74,6 +77,35 @@ using namespace std;
 
 static const char* arg0;
 
+
+char const* const BASE_OPTS[] =
+{
+    "-h",
+    "--help",
+    "-v",
+    "--version",
+    "-n:",
+    "--namespace:",
+    "-l",
+    "--link",
+    "-o:",
+    "--hosting:",
+    "-i:",
+    "--instancelifetime:",
+    "--registerdir:",
+    "--providerdir:",
+};
+
+
+void AppendBaseOpts (
+    std::vector<char const*>* pOptionsOut)
+{
+    pOptionsOut->insert (
+        pOptionsOut->begin (),
+        BASE_OPTS, BASE_OPTS + sizeof (BASE_OPTS) / sizeof (char const*));
+}
+
+
 //==============================================================================
 //
 // err()
@@ -111,11 +143,21 @@ struct Options
     string  hosting;
     bool instancelifetime;
     vector<string> nsDirs;
+    string interpreter;
+    string startup;
 
     Options() : help(false), devmode(false), instancelifetime(false)
     {
     }
-}; 
+};
+
+
+struct DefaultStartup
+{
+    std::string def;
+    std::string startup;
+};
+
 
 static void GetCommandLineDestDirOption(
     int* argc_,
@@ -160,33 +202,19 @@ static void GetCommandLineDestDirOption(
 
 static void GetCommandLineOptions( 
     int& argc, 
-    const char**& argv, 
+    const char**& argv,
+    const char** opts,
+    std::map<std::string, DefaultStartup> const& scriptMap,
     Options& options)
 {
     GetOptState state = GETOPTSTATE_INITIALIZER;
-    const char* opts[] =
-    {
-        "-h",
-        "--help",
-        "-v",
-        "--version",
-        "-n:",
-        "--namespace:",
-        "-l",
-        "--link",
-        "-o:",
-        "--hosting:",
-        "-i:",
-        "--instancelifetime:",
-        "--registerdir:",
-        "--providerdir:",
-        NULL
-    };
 
     /* For each argument */
     for (;;)
     {
         int r = GetOpt(&argc, (const char**)argv, opts, &state);
+
+        std::map<std::string, DefaultStartup>::const_iterator scriptPos;
 
         if (r == 1)
             break;
@@ -248,10 +276,23 @@ static void GetCommandLineOptions(
             if (SetPathFromNickname(state.opt+2, state.arg) != 0)
                 err(ZT("SetPathFromNickname() failed"));
         }
+        else if (scriptMap.end () != (scriptPos = scriptMap.find (state.opt)))
+        {
+            // need to check for argument, else use default.
+            options.interpreter =
+                state.arg != NULL ? state.arg : scriptPos->second.def;
+            options.startup = scriptPos->second.startup;
+        }
     }
 }
 
 typedef MI_Module* (*MainProc)(MI_Server* server);
+
+typedef MI_Module* (*StartProc)(
+    MI_Server* const server,
+    char const* const interpreter,
+    char const* const startup,
+    char const* const moduleName);
 
 static string BaseName(const string& str)
 {
@@ -429,6 +470,43 @@ static MI_Module* LoadModule(const char* path)
     return module;
 }
 
+static MI_Module* LoadModuleFromScript(
+    const char* const interpreter,
+    const char* const startup,
+    const char* const moduleName)
+{
+    const char START[] = "Start";
+    const char PROVIDER[] = "libOMIScriptProvider.so";
+
+    // load the script provider library
+    Shlib* handle = Shlib_Open(PROVIDER);
+    if (!handle)
+    {
+        TChar* msg = Shlib_Err();
+        err(ZT("failed to load %s: %T\n"), scs(PROVIDER), tcs(msg));
+    }
+
+    // Load the entry point:
+    void* sym = Shlib_Sym(handle, START);
+    if (!sym)
+    {
+        err(ZT("failed to find symbol '%s' in %s\n"), 
+            scs(START), scs(PROVIDER));
+    }
+
+    // Call Start to get MI_Module object.
+    StartProc start = reinterpret_cast<StartProc>(sym);
+    MI_Module* module = start(NULL, interpreter, startup, moduleName);
+    if (!module)
+    {
+        err(ZT("%s:%s:%s:%s:%s(): failed"),
+            scs(PROVIDER), scs(START), scs(interpreter), scs(startup),
+            scs(moduleName));
+    }
+    
+    return module;
+}
+
 static ZString _ToZString(const char* str)
 {
     ZString r;
@@ -456,10 +534,9 @@ static void GenRegFile(
 
     // Generate header line.
     Fprintf(os, "# ");
+    string arg;
     for (int i = 0; i < argc; i++)
     {
-        string arg;
-
         if (i == 0)
             arg = BaseName(argv[i]);
         else
@@ -471,8 +548,15 @@ static void GenRegFile(
     }
     Fprintf(os, "\n");
 
+    if (!opts.interpreter.empty ())
+    {
+        Fprintf (os, "INTERPRETER=%s\n", scs (opts.interpreter.c_str ()));
+        Fprintf (os, "STARTUP=%s\n", scs (opts.startup.c_str ()));
+    }
+
     // Write library name:
-    Fprintf(os, "LIBRARY=%s\n", scs(baseName.c_str()));
+    Fprintf(os, "LIBRARY=%s\n",
+            scs(opts.interpreter.empty () ? baseName.c_str() : arg.c_str ()));
 
     // Hosting
     if (!opts.hosting.empty())
@@ -602,6 +686,148 @@ static void _RefreshServer()
 #endif
 }
 
+
+static int FindConfigFile(
+    _Pre_writable_size_(PAL_MAX_PATH_SIZE) char path[PAL_MAX_PATH_SIZE])
+{
+    /* Look in current directory */
+    {
+        Strlcpy(path, "./.omiregrc", PAL_MAX_PATH_SIZE);
+
+        if (access(path, R_OK) == 0)
+            return 0;
+    }
+
+    /* Look in HOME directory */
+    char* home = Dupenv("HOME");
+    if (home)
+    {
+        Strlcpy(path, home, PAL_MAX_PATH_SIZE);
+        Strlcat(path, "/.omiregrc", PAL_MAX_PATH_SIZE);
+
+        if (access(path, R_OK) == 0)
+        {
+            PAL_Free(home);
+            return 0;
+        }
+        PAL_Free(home);
+    }
+
+    /* Look in system config directory */
+    {
+        Strlcpy(path, OMI_GetPath(ID_DESTDIR), PAL_MAX_PATH_SIZE);
+        Strlcat(path, "/", PAL_MAX_PATH_SIZE);
+        Strlcat(path, OMI_GetPath(ID_SYSCONFDIR), PAL_MAX_PATH_SIZE);
+        Strlcat(path, "/omireg.conf", PAL_MAX_PATH_SIZE);
+
+        if (access(path, R_OK) == 0)
+            return 0;
+    }
+
+    /* Not found */
+    return -1;
+}
+
+
+// script = --Python:python2.7:client.py
+int ParseTagDefaultStartup (
+    char const* value,
+    std::string* pTagOut,
+    std::string* pDefaultOut,
+    std::string* pStartupOut)
+{
+    int rval = EXIT_SUCCESS;
+    char const* tok0 = strchr (value, ':');
+    if (NULL != tok0 &&
+        tok0 != value &&
+        tok0 + 1 != '\0')
+    {
+        char const* tok1 = strchr (tok0 + 1, ':');
+        if (NULL != tok1 &&
+            tok1 != tok0 + 1 &&
+            tok1 + 1 != '\0')
+        {
+            pTagOut->assign (value, tok0 - value);
+            ++tok0;
+            pDefaultOut->assign (tok0, tok1 - tok0);
+            ++tok1;
+            pStartupOut->assign (tok1, strlen (tok1));
+        }
+        else
+        {
+            rval = EXIT_FAILURE;
+        }
+    }
+    else
+    {
+        rval = EXIT_FAILURE;
+    }
+    return rval;
+}
+
+
+static void _GetConfigFileOptions(
+    std::map<std::string, DefaultStartup>* pScriptMapOut,
+    std::vector<std::string> *pCmdOptsOut,
+    std::vector<char const*>* pCmdlnOptsOut)
+{
+    char path[PAL_MAX_PATH_SIZE];
+    Conf* conf;
+
+    /* Form the configuration file path */
+    if (FindConfigFile(path) != 0)
+        err("failed to find configuration file");
+
+    /* Open the configuration file */
+    conf = Conf_Open(path);
+    if (!conf)
+        err("failed to open configuration file: %s", path);
+
+    /* For each key=value pair in configuration file */
+    for (;;)
+    {
+        const char* key;
+        const char* value;
+        int r = Conf_Read(conf, &key, &value);
+
+        if (r == -1)
+            err("%s: %s\n", path, Conf_Error(conf));
+
+        if (r == 1)
+            break;
+
+        if (strcmp(key, "script") == 0)
+        {
+            std::string opt;
+            DefaultStartup args;
+
+            if (EXIT_SUCCESS ==
+                ParseTagDefaultStartup (
+                    value, &opt, &(args.def), &(args.startup)))
+            {
+                std::pair<std::map<std::string, DefaultStartup>::iterator,
+                          bool> r = pScriptMapOut->insert (std::make_pair (opt, args));
+                if (r.second)
+                {
+                    pCmdOptsOut->push_back (r.first->first + '?');
+                    pCmdlnOptsOut->push_back (pCmdOptsOut->back ().c_str ());
+                }
+                else
+                {
+                    err("%s(%u): duplicate key: %s",
+                        path, Conf_Line(conf), opt.c_str ());
+                }
+            }
+        }
+        else
+            err("%s(%u): unknown key: %s", path, Conf_Line(conf), key);
+    }
+
+    /* Close configuration file */
+    Conf_Close(conf);
+}
+
+
 int MI_MAIN_CALL main(int argc, const char** argv)
 {
     arg0 = argv[0];
@@ -609,10 +835,20 @@ int MI_MAIN_CALL main(int argc, const char** argv)
     // Get --destdir command-line option.
     GetCommandLineDestDirOption(&argc, argv);
 
+    std::vector<char const*> cmdlnOpts;
+    AppendBaseOpts (&cmdlnOpts);
+
+    std::map<std::string, DefaultStartup> scriptMap;
+    std::vector<std::string> cmdOpts;
+
+    _GetConfigFileOptions (&scriptMap, &cmdOpts, &cmdlnOpts);
+
+    cmdlnOpts.push_back (NULL);
+
     // Get command-line options.
     Options opts;
 
-    GetCommandLineOptions(argc, argv, opts);
+    GetCommandLineOptions(argc, argv, &(cmdlnOpts[0]), scriptMap, opts);
 
     if (opts.nsDirs.size() == 0)
     {
@@ -687,56 +923,70 @@ int MI_MAIN_CALL main(int argc, const char** argv)
 #endif
 
     {
-
-#ifndef _MSC_VER
-        vector<char> data1;
-
-        if (!Inhale(argv1, data1))
-            err(ZT("cannot read provider library: %s"), scs(argv1));
-#endif
-
-        string path = OMI_GetPath(ID_PROVIDERDIR);
-                path += "/";
-        path += Basename(argv1);
-
-#ifndef _MSC_VER
-        if (opts.devmode)
+        if (opts.interpreter.empty ())
         {
-            if (argv[1][0] != '/')
-            {
-                err(ZT("expected absolute path: '%s'"), scs(argv1));
-            }
-
-            unlink(path.c_str());
-
-            if (symlink(argv1, path.c_str()) != 0)
-            {
-                err(ZT("failed to symlink '%s' to '%s'"), 
-                    scs(argv1), scs(path.c_str()));
-            }
-        }
-        else
-        {
-#endif
-            if (File_Copy(argv1, path.c_str()) != 0)
-                err(ZT("failed to copy '%s' to '%s'"), 
-                    scs(argv1), scs(path.c_str()));
 
 #ifndef _MSC_VER
-            // set mod explicitly
-            // w by owner only; RX for all.
-            chmod(path.c_str(), 
-                S_IRUSR|S_IWUSR|S_IXUSR|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH);
+            vector<char> data1;
+
+            if (!Inhale(argv1, data1))
+                err(ZT("cannot read provider library: %s"), scs(argv1));
 #endif
 
-            Tprintf(ZT("Created %s\n"), scs(path.c_str()));
+            string path = OMI_GetPath(ID_PROVIDERDIR);
+            path += "/";
+            path += Basename(argv1);
+
 #ifndef _MSC_VER
-        }
+            if (opts.devmode)
+            {
+                if (argv[1][0] != '/')
+                {
+                    err(ZT("expected absolute path: '%s'"), scs(argv1));
+                }
+                
+                unlink(path.c_str());
+                
+                if (symlink(argv1, path.c_str()) != 0)
+                {
+                    err(ZT("failed to symlink '%s' to '%s'"), 
+                        scs(argv1), scs(path.c_str()));
+                }
+            }
+            else
+            {
 #endif
+                if (File_Copy(argv1, path.c_str()) != 0)
+                    err(ZT("failed to copy '%s' to '%s'"), 
+                        scs(argv1), scs(path.c_str()));
+
+#ifndef _MSC_VER
+                // set mod explicitly
+                // w by owner only; RX for all.
+                chmod(path.c_str(), 
+                      S_IRUSR|S_IWUSR|S_IXUSR|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH);
+#endif
+
+                Tprintf(ZT("Created %s\n"), scs(path.c_str()));
+#ifndef _MSC_VER
+            }
+#endif
+        }
     }
 
     // Load module:
-    MI_Module* module = LoadModule(argv1);
+    MI_Module* module = NULL;
+
+    if (opts.interpreter.empty ())
+    {
+        module = LoadModule(argv1);
+    }
+    else
+    {
+        module = LoadModuleFromScript (opts.interpreter.c_str(),
+                                       opts.startup.c_str (), argv1);
+    }
+
     if (!module)
         err(ZT("failed to load provider library: %s"), scs(argv1));
 

--- a/Unix/provmgr/provmgr.c
+++ b/Unix/provmgr/provmgr.c
@@ -165,16 +165,22 @@ static Library* MI_CALL _OpenLibraryInternal(
     {
         TChar path[PAL_MAX_PATH_SIZE];
         path[0] = '\0';
-        Shlib_Format(path, self->providerDir, proventry->libraryName);
+        Shlib_Format(path, self->providerDir,
+                     proventry->interpreter ? "OMIScriptProvider" :
+                         proventry->libraryName);
+
         p->handle = Shlib_Open(path);
 
         if (!p->handle)
         {
             TChar Tpath[PAL_MAX_PATH_SIZE];
 
-            if (TcsStrlcpy(Tpath, proventry->libraryName, PAL_MAX_PATH_SIZE) >= PAL_MAX_PATH_SIZE)
+            if (TcsStrlcpy(Tpath, proventry->libraryName, PAL_MAX_PATH_SIZE) >=
+                PAL_MAX_PATH_SIZE)
             {
-                trace_SharedLib_CannotOpen(scs(proventry->libraryName));
+                trace_SharedLib_CannotOpen(
+                    scs(proventry->interpreter ? "OMIScriptProvider" :
+                            proventry->libraryName));
                 PAL_Free(p);
                 return NULL;
             }
@@ -190,7 +196,8 @@ static Library* MI_CALL _OpenLibraryInternal(
 
             if (!p->handle)
             {
-                trace_SharedLib_CannotOpenSecondTry(scs(proventry->libraryName), tcs(Shlib_Err()));
+                trace_SharedLib_CannotOpenSecondTry(
+                    scs(proventry->libraryName), tcs(Shlib_Err()));
                 PAL_Free(p);
                 return NULL;
             }
@@ -201,39 +208,94 @@ static Library* MI_CALL _OpenLibraryInternal(
     Strlcpy(p->libraryName, proventry->libraryName, sizeof(p->libraryName));
     p->instanceLifetimeContext = proventry->instanceLifetimeContext;
 
-    /* Invoke MI_Main() entry point */
+    if (NULL == proventry->interpreter)
     {
-        MI_MainFunction statikMain;
-
-        /* Lookup symbol */
+        /* Invoke MI_Main() entry point */
         {
-            void* ptr = Shlib_Sym(p->handle, "MI_Main");
+            MI_MainFunction statikMain;
 
-            statikMain = (MI_MainFunction)ptr;
-
-            if (!statikMain)
+            /* Lookup symbol */
             {
-                PAL_Free(p);
-                trace_SharedLibrary_CannotFindSymbol(scs(proventry->libraryName), scs("MI_Main"));
-                return NULL;
+                void* ptr = Shlib_Sym(p->handle, "MI_Main");
+
+                statikMain = (MI_MainFunction)ptr;
+                if (!statikMain)
+                {
+                    PAL_Free(p);
+                    trace_SharedLibrary_CannotFindSymbol(
+                        scs(proventry->libraryName), scs("MI_Main"));
+                    return NULL;
+                }
+            }
+
+            /* Call MI_Main */
+            {
+                p->module = (*statikMain)(&_server);
+                if (!p->module)
+                {
+                    PAL_Free(p);
+                    trace_Provmgr_NullModulePointer(
+                        scs(proventry->libraryName), scs("MI_Main"));
+                    return NULL;
+                }
+                if (p->module->version > MI_VERSION)
+                {
+                    MI_Uint32 v =  p->module->version;
+                    PAL_Free(p);
+                    trace_Provmgr_FailedToLoadProvider(
+                        scs(proventry->libraryName), MI_VERSION_GET_MAJOR(v),
+                        MI_VERSION_GET_MINOR(v), MI_VERSION_GET_REVISION(v),
+                        MI_MAJOR, MI_MINOR, MI_REVISION);
+                    return NULL;
+                }
             }
         }
-
-        /* Call MI_Main */
+    }
+    else
+    {
+        /* Invoke MI_Main() entry point */
         {
-            p->module = (*statikMain)(&_server);
-            if (!p->module)
+            typedef MI_Module* (*StartFn)(
+                MI_Server* server,
+                char const* const interpreter,
+                char const* const startup,
+                char const* const moduleName);
+
+            StartFn start;
+            /* Lookup symbol */
             {
-                PAL_Free(p);
-                trace_Provmgr_NullModulePointer(scs(proventry->libraryName), scs("MI_Main"));
-                return NULL;
+                void* ptr = Shlib_Sym(p->handle, "Start");
+                start = (StartFn)ptr;
+                if (!start)
+                {
+                    PAL_Free(p);
+                    trace_SharedLibrary_CannotFindSymbol(
+                        scs(proventry->libraryName), scs("start"));
+                    return NULL;
+                }
             }
-            if (p->module->version > MI_VERSION)
+            /* Call start */
             {
-                MI_Uint32 v =  p->module->version;
-                PAL_Free(p);
-                trace_Provmgr_FailedToLoadProvider(scs(proventry->libraryName), MI_VERSION_GET_MAJOR(v), MI_VERSION_GET_MINOR(v), MI_VERSION_GET_REVISION(v), MI_MAJOR, MI_MINOR, MI_REVISION);
-                return NULL;
+                p->module = (*start)(
+                    &_server, proventry->interpreter, proventry->startup,
+                    p->libraryName);
+                if (!p->module)
+                {
+                    PAL_Free(p);
+                    trace_Provmgr_NullModulePointer(
+                        scs(proventry->libraryName), scs("start"));
+                    return NULL;
+                }
+                if (p->module->version > MI_VERSION)
+                {
+                    MI_Uint32 v =  p->module->version;
+                    PAL_Free(p);
+                    trace_Provmgr_FailedToLoadProvider(
+                        scs(proventry->libraryName), MI_VERSION_GET_MAJOR(v),
+                        MI_VERSION_GET_MINOR(v), MI_VERSION_GET_REVISION(v),
+                        MI_MAJOR, MI_MINOR, MI_REVISION);
+                    return NULL;
+                }
             }
         }
     }

--- a/Unix/provreg/provreg.c
+++ b/Unix/provreg/provreg.c
@@ -498,6 +498,33 @@ static int _AddEntry(
         return -1;
     }
 
+    /* ProvRegEntry.interpreter and ProvRegEntry.startup */
+    if (NULL != regFile->interpreter)
+    {
+        if (NULL != regFile->startup)
+        {
+            e->interpreter = Batch_Strdup(&self->batch, regFile->interpreter);
+            e->startup = Batch_Strdup(&self->batch, regFile->startup);
+            if (!e->interpreter || !e->startup)
+            {
+                return -1;
+            }
+        }
+        else
+        {
+            return -1;
+        }
+    }
+    else if (NULL == regFile->startup)
+    {
+        e->interpreter = NULL;
+        e->startup = NULL;
+    }
+    else
+    {
+        return -1;
+    }
+
 #if defined(CONFIG_ENABLE_PREEXEC)
 
     /* ProvRegEntry.preexec */
@@ -1235,4 +1262,78 @@ const ProvRegEntry* ProvReg_FindProviderForClassByType(
     }
     /* Not found */
     return NULL;
+}
+
+MI_EXPORT MI_Result ProvRegEntry_Clone(
+    Batch* batch,
+    const ProvRegEntry* src,
+    ProvRegEntry* dest)
+{
+    MI_Result result = MI_RESULT_OK;
+    memset(dest, 0, sizeof(ProvRegEntry));
+    dest->provInterface = src->provInterface;
+    dest->hosting = src->hosting;
+    if (src->user)
+    {
+        dest->user = Batch_Strdup(batch, src->user);
+        if (!dest->user)
+        {
+            result = MI_RESULT_FAILED;
+        }
+    }
+    if (MI_RESULT_OK == result && src->nameSpace)
+    {
+        dest->nameSpace = Batch_Strdup(batch, src->nameSpace);
+        if (!dest->nameSpace)
+        {
+            result = MI_RESULT_FAILED;
+        }
+    }
+    dest->nameSpaceHash = src->nameSpaceHash;
+    if (MI_RESULT_OK == result && src->className)
+    {
+        dest->className = Batch_Strdup(batch, src->className);
+        if (!dest->className)
+        {
+            result = MI_RESULT_FAILED;
+        }
+    }
+    dest->classNameHash = src->classNameHash;
+    if (MI_RESULT_OK == result && src->libraryName)
+    {
+        dest->libraryName = Batch_Strdup(batch, src->libraryName);
+        if (!dest->libraryName)
+        {
+            result = MI_RESULT_FAILED;
+        }
+    }
+    if (MI_RESULT_OK == result && src->interpreter)
+    {
+        dest->interpreter = Batch_Strdup(batch, src->interpreter);
+        if (!dest->interpreter)
+        {
+            result = MI_RESULT_FAILED;
+        }
+    }
+    if (MI_RESULT_OK == result && src->startup)
+    {
+        dest->startup = Batch_Strdup(batch, src->startup);
+        if (!dest->startup)
+        {
+            result = MI_RESULT_FAILED;
+        }
+    }
+#if defined(CONFIG_ENABLE_PREEXEC)
+    if (MI_RESULT_OK == result && src->preexec)
+    {
+        dest->preexec = Batch_Strdup(batch, src->preexec);
+        if (!dest->preexec)
+        {
+            result = MI_RESULT_FAILED;
+        }
+    }
+#endif /* defined(CONFIG_ENABLE_PREEXEC) */
+    dest->regType = src->regType;
+    dest->instanceLifetimeContext = src->instanceLifetimeContext;
+    return result;
 }

--- a/Unix/provreg/provreg.h
+++ b/Unix/provreg/provreg.h
@@ -85,6 +85,12 @@ typedef struct _ProvRegEntry
     /* The name library of the library containing provider */
     const char* libraryName;
 
+    /* The interpreter to use (optional and conditional) */
+    const char* interpreter;
+
+    /* The startup script to use (optional and conditional) */
+    const char* startup;
+
 #if defined(CONFIG_ENABLE_PREEXEC)
 
     /* Name of program to be executed before invoking this provider */
@@ -196,6 +202,11 @@ const ProvRegEntry* ProvReg_FindProviderForClassByType(
     _In_opt_z_ const ZChar* className,
     _In_ ProvRegType type,
     _Out_ MI_Result *findError);
+
+MI_EXPORT MI_Result ProvRegEntry_Clone(
+    Batch* batch,
+    const ProvRegEntry* src,
+    ProvRegEntry* dest);
 
 END_EXTERNC
 

--- a/Unix/provreg/regfile.c
+++ b/Unix/provreg/regfile.c
@@ -286,6 +286,9 @@ RegFile* RegFile_New(const char* path)
         return NULL;
     }
 
+    self->interpreter = NULL;
+    self->startup = NULL;
+
     /* Read line by line */
     while (fgets(buf, sizeof(buf), is) != NULL)
     {
@@ -436,6 +439,38 @@ RegFile* RegFile_New(const char* path)
             if (r == -1)
                 goto failed;
         }
+        else if (0 == strcmp (key, "INTERPRETER"))
+        {
+            if (self->interpreter)
+            {
+                goto failed;
+            }
+            if (NULL == value || 0 == strlen (value))
+            {
+                goto failed;
+            }
+            self->interpreter = PAL_Strdup(value);
+            if (!self->interpreter)
+            {
+                goto failed;
+            }
+        }
+        else if (0 == strcmp (key, "STARTUP"))
+        {
+            if (self->startup)
+            {
+                goto failed;
+            }
+            if (NULL == value || 0 == strlen (value))
+            {
+                goto failed;
+            }
+            self->startup = PAL_Strdup(value);
+            if (!self->startup)
+            {
+                goto failed;
+            }
+        }
     }
 
     if (hosting)
@@ -494,6 +529,12 @@ void RegFile_Delete(RegFile* self)
 
     if (self->library)
         PAL_Free(self->library);
+
+    if (self->interpreter)
+        PAL_Free(self->interpreter);
+
+    if (self->startup)
+        PAL_Free(self->startup);
 
 #if defined(CONFIG_ENABLE_PREEXEC)
 

--- a/Unix/provreg/regfile.h
+++ b/Unix/provreg/regfile.h
@@ -39,6 +39,8 @@ RegClass;
 typedef struct _RegFile
 {
     char* library;
+    char* interpreter;
+    char* startup;
 
 #if defined(CONFIG_ENABLE_PREEXEC)
 


### PR DESCRIPTION
These changes are needed to support the OMI-Script-Provider.

getopt.c:
    added option arguments for command line args

configure:
    added registration for omireg.conf

Base_OMI.data:
    added file placement for omireg.conf

omireg.cpp:
    added a configuration file to allow future additions for new scripting languages without core changes
    added opening processing for script providers
    added new arguments to the output files to support scripting providers

provmgr.c:
    added an alternative processing case to handle scripting providers

provereg.[ch]:
    added the members "interpreter" and "startup" to ProvRegEntry

regfile.[ch]:
    added the members "interpreter" and "startup" to RegFile

messages.[ch]:
    replaced "libraryName" and "instanceLifetimeContext" with "regEntry" in the RequestMsg structure.

agent.c:
    support for the changes to the content of the RequestMsg data structure

agentmgr.c:
    support for the changes to the content of the RequestMsg data structure