### PR TITLE
Validate SSL version in the preinstall script for native installer.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /Unix/output4
 /Unix/output_openssl_0.9.8/
 /Unix/output_openssl_1.0.0/
+/Unix/output_openssl_1.1.0/
 nits.log
 /Unix/tests/oi/out.c.txt
 /Unix/etc/ssl/certs/omikey.pem

--- a/Unix/configure
+++ b/Unix/configure
@@ -2497,6 +2497,7 @@ if [ "$disable_makefile_gen" != "1" ]; then
 
 __ROOT=$root
 export OUTPUTDIR=$outputdir
+export SSL_BUILD
 export ROOT=$root
 export ENABLE_ULINUX=$enable_ulinux
 export ENABLE_NATIVE_KITS=$enable_native_kits
@@ -2517,21 +2518,21 @@ ifneq (\$(DISABLE_SSL_0_9_8),1)
 
 	@echo Running: ./configure \$(OMI_CONFIGURE_QUALS) --outputdirname=output_openssl_0.9.8 --opensslcflags="${openssl098_cflags}" --openssllibs="${openssl098_libs}" --openssllibdir="${openssl098_libdir}"; \
 	./configure \$(OMI_CONFIGURE_QUALS) --outputdirname=output_openssl_0.9.8 --opensslcflags="${openssl098_cflags}" --openssllibs="${openssl098_libs}" --openssllibdir="${openssl098_libdir}"; \
-	( cd \$(__ROOT); OUTPUTDIR=${root}/output_openssl_0.9.8; \$(MAKE) -f build.mak )
+	( cd \$(__ROOT); OUTPUTDIR=${root}/output_openssl_0.9.8; SSL_BUILD=0.9.8; \$(MAKE) -f build.mak )
 endif
 
 	@echo '========================= Performing Building OMI (SSL 1.0.0)'
 
 	echo Running: ./configure \$(OMI_CONFIGURE_QUALS) --outputdirname=output_openssl_1.0.0 --opensslcflags="${openssl100_cflags}" --openssllibs="${openssl100_libs}" --openssllibdir="${openssl100_libdir}"; \
 	./configure \$(OMI_CONFIGURE_QUALS) --outputdirname=output_openssl_1.0.0 --opensslcflags="${openssl100_cflags}" --openssllibs="${openssl100_libs}" --openssllibdir="${openssl100_libdir}"; \
-	( cd \$(__ROOT); OUTPUTDIR=${root}/output_openssl_1.0.0; \$(MAKE) -f build.mak )
+	( cd \$(__ROOT); OUTPUTDIR=${root}/output_openssl_1.0.0; SSL_BUILD=1.0.0; \$(MAKE) -f build.mak )
 
 ifneq (\$(DISABLE_SSL_1_1_0),1)
 	@echo '========================= Performing Building OMI (SSL 1.1.0)'
 
 	echo Running: ./configure \$(OMI_CONFIGURE_QUALS) --outputdirname=output_openssl_1.1.0 --opensslcflags="${openssl110_cflags}" --openssllibs="${openssl110_libs}" --openssllibdir="${openssl110_libdir}"; \
 	./configure \$(OMI_CONFIGURE_QUALS) --outputdirname=output_openssl_1.1.0 --opensslcflags="${openssl110_cflags}" --openssllibs="${openssl110_libs}" --openssllibdir="${openssl110_libdir}"; \
-	( cd \$(__ROOT); OUTPUTDIR=${root}/output_openssl_1.1.0; \$(MAKE) -f build.mak )
+	( cd \$(__ROOT); OUTPUTDIR=${root}/output_openssl_1.1.0; SSL_BUILD=1.1.0; \$(MAKE) -f build.mak )
 endif
 
 else

--- a/Unix/installbuilder/GNUmakefile
+++ b/Unix/installbuilder/GNUmakefile
@@ -69,6 +69,11 @@ ifdef SSL_VERSION
 OUTPUTFILE_LINE = --OUTPUTFILE=omi-$(CONFIG_VERSION).ssl_$(SSL_VERSION).$(PF_ARCH)
 endif
 
+# SSL version we're building for (for package validation in preinstall script)
+ifdef SSL_BUILD
+  SSL_BUILD_LINE = --SSL_BUILD_VERSION=$(SSL_BUILD)
+endif
+
 all:
 ifneq ($(PF),Darwin)
   ifneq ($(PF),Linux)
@@ -112,6 +117,7 @@ ifneq ($(PF),Darwin)
 		--VERSION=$(CONFIG_VERSION) \
 		--RELEASE=$(CONFIG_PATCH_LEVEL) \
 		$(OUTPUTFILE_LINE) \
+		$(SSL_BUILD_LINE) \
 		--DATAFILE_PATH=$(TOP)/installbuilder/datafiles \
 		$(DATAFILES) Linux_RPM.data
     endif # ifeq ($(BUILD_RPM),1)
@@ -135,6 +141,7 @@ ifneq ($(PF),Darwin)
 		--VERSION=$(CONFIG_VERSION) \
 		--RELEASE=$(CONFIG_PATCH_LEVEL) \
 		$(OUTPUTFILE_LINE) \
+		$(SSL_BUILD_LINE) \
 		--DPKG_LOCATION=$(TOP)/../../pal/installer/InstallBuilder/tools/bin/dpkg-deb-$(PF_ARCH) \
 		--DATAFILE_PATH=$(TOP)/installbuilder/datafiles \
 		$(DATAFILES) Linux_DPKG.data

--- a/Unix/installbuilder/datafiles/Linux.data
+++ b/Unix/installbuilder/datafiles/Linux.data
@@ -174,6 +174,34 @@ ConfigureOmiService() {
 %Preinstall_10
 #include OmiService_funcs
 
+# Verify that the proper version of SSL is installed (if we're on ULINUX)
+
+SSL_VERSION=`openssl version | awk '{print $2}'`
+case "$SSL_VERSION" in
+    0.9.8*)
+	SSL_FOUND=0.9.8
+        ;;
+    1.0.*)
+        SSL_FOUND=1.0.0
+        ;;
+    1.1.*)
+        SSL_FOUND=1.1.0
+        ;;
+    *)
+        echo "Preinstall script error: Unrecognized version of SSL on the system: $SSL_VERSION" >&2
+        exit 2
+        ;;
+esac
+
+if [ "${{PFDISTRO}}" = "ULINUX" -a "$SSL_FOUND" != "${{SSL_BUILD_VERSION}}" ]; then
+    echo "Expecting SSL version compatible with ${{SSL_BUILD_VERSION}}," >&2
+    echo "but found SSL version ${SSL_VERSION}. Please be certain that" >&2
+    echo "you are installing correct version of OMI kit for your system." >&2
+    exit 3
+fi
+
+# Continue with service setup and group handling
+
 RemoveGenericService omiserverd
 RemoveGenericService scx-cimd
 RemoveOmiService
@@ -207,8 +235,6 @@ chmod 500 /opt/omi/bin/support/config_keytab_update.sh
 /opt/omi/bin/support/config_keytab_update.sh --configure
 
 ConfigureOmiService
-
-
 
 %Preuninstall_10
 #include OmiService_funcs


### PR DESCRIPTION
For Linux only, where we build kits for multiple versions of SSL,
validate that the installed version of SSL is compatible with the
kit type that is being installed. This ensures that the OMI kit
that customer is installing can at least launch on destination
system.

@Microsoft/ostc-devs @Microsoft/omi-devs 