### PR TITLE
Change how ULINUX is determined for InstallBuilder (fix AIXPPC platform).

### DIFF
--- a/Unix/installbuilder/GNUmakefile
+++ b/Unix/installbuilder/GNUmakefile
@@ -31,6 +31,10 @@ COMPRESS_KIT = 0
 ifeq ($(PF),Linux)
 DATAFILES += Linux.data
 endif
+ifeq ($(PF_DISTRO),ULINUX)
+DATAFILES += ULinux.data
+endif
+
 ifeq ($(PF),AIX)
 DATAFILES += AIX.data AIX_$(PF_MAJOR).data
 endif

--- a/Unix/installbuilder/datafiles/Linux.data
+++ b/Unix/installbuilder/datafiles/Linux.data
@@ -174,34 +174,6 @@ ConfigureOmiService() {
 %Preinstall_10
 #include OmiService_funcs
 
-# Verify that the proper version of SSL is installed (if we're on ULINUX)
-
-SSL_VERSION=`openssl version | awk '{print $2}'`
-case "$SSL_VERSION" in
-    0.9.8*)
-	SSL_FOUND=0.9.8
-        ;;
-    1.0.*)
-        SSL_FOUND=1.0.0
-        ;;
-    1.1.*)
-        SSL_FOUND=1.1.0
-        ;;
-    *)
-        echo "Preinstall script error: Unrecognized version of SSL on the system: $SSL_VERSION" >&2
-        exit 2
-        ;;
-esac
-
-if [ "${{PFDISTRO}}" = "ULINUX" -a "$SSL_FOUND" != "${{SSL_BUILD_VERSION}}" ]; then
-    echo "Expecting SSL version compatible with ${{SSL_BUILD_VERSION}}," >&2
-    echo "but found SSL version ${SSL_VERSION}. Please be certain that" >&2
-    echo "you are installing correct version of OMI kit for your system." >&2
-    exit 3
-fi
-
-# Continue with service setup and group handling
-
 RemoveGenericService omiserverd
 RemoveGenericService scx-cimd
 RemoveOmiService

--- a/Unix/installbuilder/datafiles/ULinux.data
+++ b/Unix/installbuilder/datafiles/ULinux.data
@@ -1,0 +1,37 @@
+%Variables
+
+%Files
+
+%Directories
+
+%Defines
+
+%Preinstall_5
+
+# Verify that the proper version of SSL is installed
+
+SSL_VERSION=`openssl version | awk '{print $2}'`
+case "$SSL_VERSION" in
+    0.9.8*)
+	SSL_FOUND=0.9.8
+        ;;
+    1.0.*)
+        SSL_FOUND=1.0.0
+        ;;
+    1.1.*)
+        SSL_FOUND=1.1.0
+        ;;
+    *)
+        echo "Preinstall script error: Unrecognized version of SSL on the system: $SSL_VERSION" >&2
+        exit 2
+        ;;
+esac
+
+if [ "$SSL_FOUND" != "${{SSL_BUILD_VERSION}}" ]; then
+    echo "Expecting SSL version (compatible with): ${{SSL_BUILD_VERSION}}" >&2
+    echo "SSL version found on system:             ${SSL_VERSION}" >&2
+    echo "" >&2
+    echo "Incorrect version of OMI for your system, please check SSL version." >&2
+    exit 3
+fi
+


### PR DESCRIPTION
ULINUX is sufficiently different that Linux where it makes sense to
have a separate InstallBuilder datafile just for ULINUX. This makes
it easier to inject ULINUX-specific code into pre/post installation
scripts.

@Microsoft/ostc-devs @Microsoft/omi-devs 

Note that my last change broke the nightly build (OMI doesn't, by default, build packages in PBUILD). This is somewhat involved to fix in PBUILD (requires changes to .pbuild file for build hosts), will discuss that with the team.