### PR TITLE
Added support for building OMI with symbols.

### DIFF
--- a/Unix/buildtool
+++ b/Unix/buildtool
@@ -774,16 +774,16 @@ if [ "$arg1" = "cflags" -o "$arg1" = "cxxflags" ]; then
 
     r=""
 
+    ## Always build with debug symbols
+    r="$r -g"
+
     case "$platform" in
         LINUX_IX86_GNU|LINUX_X86_64_GNU|LINUX_PPC_GNU|MONTAVISTA_IX86_GNU|NETBSD_IX86_GNU|LINUX_ARM_GNU)
-
             if test $cxx_opt ; then
                 r="$r -std=gnu++98"
             fi    
 
-            if test -n "$debug_opt"; then
-                r="$r -g"
-            else
+            if test -z "$debug_opt"; then
                 if test -n "$size_opt"; then
                     r="$r -Os"
                 else
@@ -823,10 +823,6 @@ if [ "$arg1" = "cflags" -o "$arg1" = "cxxflags" ]; then
             #test -n "$cxx_opt" && r="$r -fno-rtti"
             ;;
         SUNOS_I86PC_SUNPRO|SUNOS_SPARC_SUNPRO)
-
-            ## Debugger options.
-            test -n "$debug_opt" && r="$r -g"
-
             ## Optimization options.
             if test -z "$debug_opt"; then
                 test -n "$c_opt" && r="$r"
@@ -876,7 +872,6 @@ if [ "$arg1" = "cflags" -o "$arg1" = "cxxflags" ]; then
             
             ;;
         AIX_PPC_IBM)
-            test -n "$debug_opt" && r="$r -g"
             test -n "$debug_opt" && r="$r -qcheck"
             test -z "$debug_opt" && r="$r -O2"
             test -n "$pic_opt" && r="$r -qpic"
@@ -890,7 +885,6 @@ if [ "$arg1" = "cflags" -o "$arg1" = "cxxflags" ]; then
             ## r="$r -qstackprotect=all"
             ;;
         HPUX_IA64_HP)
-            test -n "$debug_opt" && r="$r -g"
             test -z "$debug_opt" && r="$r -s +O1"
             ## treat warnings as errors.
             test -n "$errwarn_opt" && r="$r +We"
@@ -904,7 +898,9 @@ if [ "$arg1" = "cflags" -o "$arg1" = "cxxflags" ]; then
             r="$r -D__STDC_EXT__"
             ;;
         HPUX_PARISC_HP)
-            test -n "$debug_opt" && r="$r -g +noobjdebug"
+            ## Always build with debug symbols
+            r="$r +noobjdebug"
+
             test -z "$debug_opt" && r="$r +O2 -s"
             ## treat warnings as errors.
             test -n "$errwarn_opt" && r="$r +We"
@@ -921,7 +917,6 @@ if [ "$arg1" = "cflags" -o "$arg1" = "cxxflags" ]; then
             r="$r -D_XOPEN_SOURCE_EXTENDED"
             ;;
         DARWIN_IX86_GNU)
-            test -n "$debug_opt" && r="$r -g"
             test -z "$debug_opt" && r="$r -O2"
             test -n "$pic_opt" && r="$r -fPIC"
             ## treat warnings as errors.

--- a/Unix/installbuilder/GNUmakefile
+++ b/Unix/installbuilder/GNUmakefile
@@ -63,14 +63,43 @@ endif
 ifeq ($(PF),Linux)
   ifneq ($(PF_ARCH),ppc)
     OUTPUTFILE_LINE = --OUTPUTFILE=omi-$(CONFIG_VERSION)-$(CONFIG_PATCH_LEVEL).$(PACKAGE_SSL_DECORATION).ulinux.$(PF_ARCH)
+    OUTPUTFILE_LINE_WITHSYMBOLS = $(OUTPUTFILE_LINE).withsymbols
   else
     OUTPUTFILE_LINE = --OUTPUTFILE=omi-$(CONFIG_VERSION)-$(CONFIG_PATCH_LEVEL).rhel.$(PF_MAJOR).$(PF_ARCH)
+    OUTPUTFILE_LINE_WITHSYMBOLS = $(OUTPUTFILE_LINE).withsymbols
   endif
+endif
+ifeq ($(PF),AIX)
+    OUTPUTFILE_LINE = --OUTPUTFILE=omi-$(CONFIG_VERSION)-$(CONFIG_PATCH_LEVEL).aix.$(PF_MAJOR).$(PF_ARCH)
+    OUTPUTFILE_LINE_WITHSYMBOLS = $(OUTPUTFILE_LINE).withsymbols
+endif
+ifeq ($(PF),HPUX)
+  ifeq ($(PF_ARCH), pa-risc)
+    OUTPUTFILE_LINE_ARCH = parisc
+  else
+    OUTPUTFILE_LINE_ARCH = $(PF_ARCH)
+  endif
+
+  OUTPUTFILE_LINE = --OUTPUTFILE=omi-$(CONFIG_VERSION)-$(CONFIG_PATCH_LEVEL).hpux.11iv3.$(OUTPUTFILE_LINE_ARCH)
+  OUTPUTFILE_LINE_WITHSYMBOLS = $(OUTPUTFILE_LINE).withsymbols
+endif
+
+ifeq ($(PF),SunOS)
+  OUTPUTFILE_LINE = --OUTPUTFILE=omi-$(CONFIG_VERSION)-$(CONFIG_PATCH_LEVEL).solaris.$(PF_MINOR).$(PF_ARCH)
+  OUTPUTFILE_LINE_WITHSYMBOLS = $(OUTPUTFILE_LINE).withsymbols
+endif
+
+# Where does "strip" utility live?
+ifeq ($(PF),Linux)
+  STRIP_PATH=strip
+else
+  STRIP_PATH=/usr/ccs/bin/strip
 endif
 
 # DSC output format (used by DSC installbuilder Makefile)
 ifdef SSL_VERSION
 OUTPUTFILE_LINE = --OUTPUTFILE=omi-$(CONFIG_VERSION).ssl_$(SSL_VERSION).$(PF_ARCH)
+OUTPUTFILE_LINE_WITHSYMBOLS = $(OUTPUTFILE_LINE).withsymbols
 endif
 
 # SSL version we're building for (for package validation in preinstall script)
@@ -81,9 +110,30 @@ endif
 all:
 ifneq ($(PF),Darwin)
   ifneq ($(PF),Linux)
-	@echo "========================= Make OMI installer $(PF_DISTRO)"
+	@echo "========================= Make OMI installer $(PF_DISTRO) with symbols"
 	sudo rm -rf $(OUTPUTDIR)/intermediate/staging
 	mkdir -p $(OUTPUTDIR)/release $(OUTPUTDIR)/intermediate
+	python $(TOP)/../../pal/installer/InstallBuilder/installbuilder.py \
+		--BASE_DIR=$(OUTPUTDIR) \
+		--TARGET_DIR=$(OUTPUTDIR)/release \
+		--INTERMEDIATE_DIR=$(OUTPUTDIR)/intermediate \
+		--STAGING_DIR=$(OUTPUTDIR)/intermediate/staging \
+		--PF=$(PF) \
+		--PFMAJOR=$(PF_MAJOR) \
+		--PFMINOR=$(PF_MINOR) \
+		--PFARCH=$(PF_ARCH) \
+		--PFDISTRO=$(PF_DISTRO) \
+		--VERSION=$(CONFIG_VERSION) \
+		--RELEASE=$(CONFIG_PATCH_LEVEL) \
+		$(OUTPUTFILE_LINE_WITHSYMBOLS) \
+		--DATAFILE_PATH=$(TOP)/installbuilder/datafiles \
+		$(DATAFILES)
+
+	@echo "========================= Make OMI installer $(PF_DISTRO) without symbols"
+	sudo rm -rf $(OUTPUTDIR)/intermediate/staging
+	mkdir -p $(OUTPUTDIR)/release $(OUTPUTDIR)/intermediate
+	$(STRIP_PATH) $(OUTPUTDIR)/bin/*
+	$(STRIP_PATH) $(OUTPUTDIR)/lib/*.so
 	python $(TOP)/../../pal/installer/InstallBuilder/installbuilder.py \
 		--BASE_DIR=$(OUTPUTDIR) \
 		--TARGET_DIR=$(OUTPUTDIR)/release \
@@ -105,7 +155,58 @@ ifneq ($(PF),Darwin)
     endif
   else # ifneq ($(PF),Linux)
     ifeq ($(BUILD_RPM),1)
-	@echo "========================= Make OMI installer RPM"
+	@echo "========================= Make OMI installer RPM with symbols"
+	sudo rm -rf $(OUTPUTDIR)/intermediate/staging
+	mkdir -p $(OUTPUTDIR)/release $(OUTPUTDIR)/intermediate
+	python $(TOP)/../../pal/installer/InstallBuilder/installbuilder.py \
+		--BASE_DIR=$(OUTPUTDIR) \
+		--TARGET_DIR=$(OUTPUTDIR)/release \
+		--INTERMEDIATE_DIR=$(OUTPUTDIR)/intermediate \
+		--STAGING_DIR=$(OUTPUTDIR)/intermediate/staging \
+		--PF=$(PF) \
+		--PFMAJOR=$(PF_MAJOR) \
+		--PFMINOR=$(PF_MINOR) \
+		--PFARCH=$(PF_ARCH) \
+		--PFDISTRO=$(PF_DISTRO) \
+		--VERSION=$(CONFIG_VERSION) \
+		--RELEASE=$(CONFIG_PATCH_LEVEL) \
+		$(OUTPUTFILE_LINE_WITHSYMBOLS) \
+		$(SSL_BUILD_LINE) \
+		--DATAFILE_PATH=$(TOP)/installbuilder/datafiles \
+		$(DATAFILES) Linux_RPM.data
+    endif # ifeq ($(BUILD_RPM),1)
+    ifeq ($(BUILD_DPKG),1)
+	egrep -q "^omiusers:" /etc/group; if [ $$? -ne 0 ]; then echo "Creating omiusers group ..."; sudo /usr/sbin/groupadd -r omiusers; fi
+
+	@echo "========================= Make OMI installer DPKG with symbols"
+	sudo rm -rf $(OUTPUTDIR)/intermediate/staging
+	mkdir -p $(OUTPUTDIR)/release $(OUTPUTDIR)/intermediate
+	ls -l $(TOP)/../../pal/installer/InstallBuilder/tools/bin/dpkg-deb-x64
+	python $(TOP)/../../pal/installer/InstallBuilder/installbuilder.py \
+		--BASE_DIR=$(OUTPUTDIR) \
+		--TARGET_DIR=$(OUTPUTDIR)/release \
+		--INTERMEDIATE_DIR=$(OUTPUTDIR)/intermediate \
+		--STAGING_DIR=$(OUTPUTDIR)/intermediate/staging \
+		--PF=$(PF) \
+		--PFMAJOR=$(PF_MAJOR) \
+		--PFMINOR=$(PF_MINOR) \
+		--PFARCH=$(PF_ARCH) \
+		--PFDISTRO=$(PF_DISTRO) \
+		--VERSION=$(CONFIG_VERSION) \
+		--RELEASE=$(CONFIG_PATCH_LEVEL) \
+		$(OUTPUTFILE_LINE_WITHSYMBOLS) \
+		$(SSL_BUILD_LINE) \
+		--DPKG_LOCATION=$(TOP)/../../pal/installer/InstallBuilder/tools/bin/dpkg-deb-$(PF_ARCH) \
+		--DATAFILE_PATH=$(TOP)/installbuilder/datafiles \
+		$(DATAFILES) Linux_DPKG.data
+    endif # ifeq ($(BUILD_DPKG),1)
+
+	# Strip the symbols from the binary and library files
+	$(STRIP_PATH) $(OUTPUTDIR)/bin/*
+	$(STRIP_PATH) $(OUTPUTDIR)/lib/*.so
+
+    ifeq ($(BUILD_RPM),1)
+	@echo "========================= Make OMI installer RPM without symbols"
 	sudo rm -rf $(OUTPUTDIR)/intermediate/staging
 	mkdir -p $(OUTPUTDIR)/release $(OUTPUTDIR)/intermediate
 	python $(TOP)/../../pal/installer/InstallBuilder/installbuilder.py \
@@ -126,9 +227,7 @@ ifneq ($(PF),Darwin)
 		$(DATAFILES) Linux_RPM.data
     endif # ifeq ($(BUILD_RPM),1)
     ifeq ($(BUILD_DPKG),1)
-	egrep -q "^omiusers:" /etc/group; if [ $$? -ne 0 ]; then echo "Creating omiusers group ..."; sudo /usr/sbin/groupadd -r omiusers; fi
-
-	echo "========================= Make OMI installer DPKG"
+	@echo "========================= Make OMI installer DPKG without symbols"
 	sudo rm -rf $(OUTPUTDIR)/intermediate/staging
 	mkdir -p $(OUTPUTDIR)/release $(OUTPUTDIR)/intermediate
 	ls -l $(TOP)/../../pal/installer/InstallBuilder/tools/bin/dpkg-deb-x64


### PR DESCRIPTION
Two changes were made:

1) Modified build to include symbols within the build,
2) Modified installbuilder to make kits both with and without
   symbols.

@Microsoft/omi-devs @Microsoft/ostc-devs 