### PR TITLE
Clean up omiserver.conf

### DIFF
--- a/Unix/etc/omiserver.conf
+++ b/Unix/etc/omiserver.conf
@@ -16,17 +16,14 @@
 #idletimeout=TIMEOUT
 
 ##
-## trace -- enable tracing to standard output (default is 'false')
+## loglevel -- set the loggiing options for MI server
+##   Valid options are: ERROR, WARNING, INFO, DEBUG, VERBOSE (debug builds only)
+##   If commented out, then default value is: WARNING
 ##
-#trace=(true|false)
+#loglevel = WARNING
 
 ##
-## loglevel -- set the log level of the server
-##
-loglevel = WARNING
-
-##
-## <NICKNAME> -- set the value of nickname.
+## Settings for omi-related directory and file paths when building from source code.
 ##
 #prefix=PATH
 #libdir=PATH
@@ -49,18 +46,29 @@ loglevel = WARNING
 #serverprogram=PATH
 #includedir=PATH
 #configfile=PATH
-NoSSLv2=true
-NoSSLv3=false
-NoTLSv1_0=false
-NoTLSv1_1=false
-NoTLSv1_2=false
-NoSSLCompression=false
-#NtlmCredsFile=PATH
-# For example
+
+##
+## This section is for security protocol settings
+##   NoSSLv2: When it is true, the SSLv2 protocol is disabled.
+##   NoSSLv3: When it is true, the SSLv3 protocol is disabled.
+##   If NoSSLv2 and NoSSLv3 are both set to true, only TLS encryption will be negotiated.
+##
+#NoSSLv2=true
+#NoSSLv3=false
+
+##
+## NtlmCredsFile -- credentials file for NTLM authentication
+##
+## To enable NTLM authentication via negotiation (SPNEGO), specify the
+## location of the credentials file. This file is in the form:
+##
+##   <domain>:<username>:<password>
+##
+## More detail: https://github.com/Microsoft/omi/blob/master/Unix/doc/setup-ntlm-omi.md
+##
 #NtlmCredsFile=/etc/opt/omi/.creds/ntlm
 
-## non-root feature parameters
+## non-root feature parameters, this is only for building the source code.
 ## if USER is specified within <> as the service account, 
 ##      it will be replaced with $USER when copied to output*
-#nonroot=true
 service=<USER>

--- a/Unix/installbuilder/conf/omiserver.conf
+++ b/Unix/installbuilder/conf/omiserver.conf
@@ -16,9 +16,11 @@ httpsport=0
 #idletimeout=TIMEOUT
 
 ##
-## trace -- enable tracing to standard output (default is 'false')
+## loglevel -- set the loggiing options for MI server
+##   Valid options are: ERROR, WARNING, INFO, DEBUG, VERBOSE (debug builds only)
+##   If commented out, then default value is: WARNING
 ##
-#trace=(true|false)
+#loglevel = WARNING
 
 ##
 ## NtlmCredsFile -- credentials file for NTLM authentication
@@ -33,31 +35,19 @@ httpsport=0
 #NtlmCredsFile=/etc/opt/omi/.creds/ntlm
 
 ##
-## <NICKNAME> -- set the value of nickname.
+##  Settings for omi-related directory and file paths.
+##  You can modify below default path value to other location.
 ##
-#prefix=PATH
-#libdir=PATH
-#bindir=PATH
-#localstatedir=PATH
-#sysconfdir=PATH
-#providerdir=PATH
-#certsdir=PATH
-#datadir=PATH
-rundir=/var/opt/omi/run
-#logdir=PATH
-#schemadir=PATH
-#schemafile=PATH
-pidfile=/var/opt/omi/run/omiserver.pid
-logfile=/var/opt/omi/log/omiserver.log
-registerdir=/etc/opt/omi/conf/omiregister
-pemfile=/etc/opt/omi/ssl/omi.pem
-keyfile=/etc/opt/omi/ssl/omikey.pem
-#agentprogram=PATH
-#serverprogram=PATH
-#includedir=PATH
-configfile=/etc/opt/omi/conf/omiserver.conf
+
+## omi log folder and log file
+#logdir=/var/opt/omi/log
+#logfile=/var/opt/omi/log/omiserver.log
+
+##
+## This section is for security protocol settings
+##   NoSSLv2: When it is true, the SSLv2 protocol is disabled.
+##   NoSSLv3: When it is true, the SSLv3 protocol is disabled.
+##   If NoSSLv2 and NoSSLv3 are both set to true, only TLS encryption will be negotiated.
+##
 #NoSSLv2=true
 #NoSSLv3=false
-
-## non-root feature parameters
-#nonroot=true


### PR DESCRIPTION
@Microsoft/omi-devs , could you help to review this PR? thanks very much!
here are changes:
1. Remove trace setting for both Unix/installbuilder/conf/omiserver.conf and Unix/etc/omiserver.conf (trace setting doesn't work, so remove it.)
2. Update loglevel section for Unix/etc/omiserver.conf
3. Add loglevel section for Unix/installbuilder/conf/omiserver.conf 
4. Remove nonroot setting for both Unix/installbuilder/conf/omiserver.conf and Unix/etc/omiserver.conf
5. Update NICKNAME section description

For NICKNAME section, I have tried all below setting, they works fine:
```
prefix=GNU
libdir=/opt/omi/lib
bindir=/opt/omi/bin
localstatedir=/var/opt/omi
sysconfdir=/etc/opt/omi/conf
providerdir=/etc/opt/omi/conf
certsdir=/etc/opt/omi/ssl
datadir=/opt/omi/share
rundir=/var/opt/omi/run
logdir=/var/opt/omi/log
schemadir=/opt/omi/share/omischema
schemafile=/opt/omi/share/omischema/CIM_Schema.mof
pidfile=/var/opt/omi/run/omiserver.pid
logfile=/var/opt/omi/log/omiserver.log
registerdir=/etc/opt/omi/conf/omiregister
pemfile=/etc/opt/omi/ssl/omi.pem
keyfile=/etc/opt/omi/ssl/omikey.pem
agentprogram=/opt/omi/bin/omiagent
serverprogram=/opt/omi/bin/omiserver
includedir=/opt/omi/include
configfile=/etc/opt/omi/conf/omiserver.conf
```