### PR TITLE
Remove ENCRYPT_DECRYPYT flag from build tool.

### DIFF
--- a/Unix/buildtool
+++ b/Unix/buildtool
@@ -800,7 +800,6 @@ if [ "$arg1" = "cflags" -o "$arg1" = "cxxflags" ]; then
             r="$r -fstack-protector-all"
             r="$r -D_GNU_SOURCE"
             r="$r -D_XOPEN_SOURCE=600"
-            r="$r -DENCRYPT_DECRPYT"
             r="$r -DGSS_USE_IOV=1"
 
 	        # _BSD_SOURCE is deprecated on PPC and gcc 6 and later


### PR DESCRIPTION
Misspelled, and not needed anyway since it's in config.h.