### PR TITLE
Fix occassional errors seen in pbuild

### DIFF
--- a/Unix/engine/engine.c
+++ b/Unix/engine/engine.c
@@ -105,6 +105,16 @@ int enginemain(int argc, const char* argv[])
         }
     }
 
+#if defined(CONFIG_POSIX)
+    /* reset signal handlers */
+    if (0 != SetSignalHandler(SIGTERM, SIG_DFL) ||
+        0 != SetSignalHandler(SIGHUP, SIG_DFL) ||
+        0 != SetSignalHandler(SIGUSR1, SIG_DFL))
+    {
+        err(ZT("cannot reset sighandler, errno %d"), errno);
+    }
+#endif
+
     Sock_Close(s_opts.socketpairPort);
     ServerCleanup(pidfile);
 

--- a/Unix/pal/atexit.c
+++ b/Unix/pal/atexit.c
@@ -63,8 +63,6 @@ int PAL_Atexit(void (*func)())
     /* Disallow if currently executing PAL_AtexitCall() */
     pthread_mutex_lock(&_nestingLock);
     {
-        DEBUG_ASSERT(_nesting == 0);
-
         if (_nesting)
         {
             pthread_mutex_unlock(&_nestingLock);

--- a/Unix/server/server.c
+++ b/Unix/server/server.c
@@ -630,6 +630,17 @@ int servermain(int argc, const char* argv[], const char *envp[])
     }
 
 cleanup:
+
+#if defined(CONFIG_POSIX)
+    /* reset signal handlers */
+    if (0 != SetSignalHandler(SIGTERM, SIG_DFL) ||
+        0 != SetSignalHandler(SIGHUP, SIG_DFL) ||
+        0 != SetSignalHandler(SIGCHLD, SIG_DFL))
+    {
+        err(ZT("cannot reset sighandler, errno %d"), errno);
+    }
+#endif
+
     PAL_Free(engine_argv);
 
     if (engine_envp) 


### PR DESCRIPTION
1. Remove signal handlers after run loop.
2. Remove DEBUG_ASSERT in PAL_Atexit that occassionally crashes in unit-testing