### PR TITLE
Fix occassional unit-test core-dump

### DIFF
--- a/Unix/pal/atexit.c
+++ b/Unix/pal/atexit.c
@@ -112,8 +112,6 @@ int PAL_AtexitCall()
     /* Disallow if currently executing PAL_AtexitCall() */
     pthread_mutex_lock(&_nestingLock);
     {
-        DEBUG_ASSERT(_nesting == 0);
-
         if (_nesting)
         {
             pthread_mutex_unlock(&_nestingLock);


### PR DESCRIPTION
Unnecessary assert.  Fixed previously for PAL_Atexit() also, but forgot to fix PAL_AtexitCall().  