### PR TITLE
Add access denied error message for reg files

### DIFF
--- a/Unix/base/oi_traces.h
+++ b/Unix/base/oi_traces.h
@@ -426,6 +426,9 @@ void trace_HTTP_ClientAuthFailed(const char * major, const char * minor);
 OI_EVENT("Failed to send auth response to client")
 void trace_ClientAuthResponseFailed();
 
+OI_EVENT("Reg file %s access denied. It will be skipped by the server")
+void trace_ProvReg_AccessDeniedRegFile(const char * filePath);
+
 
 /******************************** WARNINGS ***********************************/
 

--- a/Unix/base/oiomi.h
+++ b/Unix/base/oiomi.h
@@ -1097,6 +1097,12 @@ FILE_EVENT2(20147, trace_HTTP_ClientAuthFailed_Impl, LOG_ERR, PAL_T("HTTP: Clien
 #endif
 FILE_EVENT0(20148, trace_ClientAuthResponseFailed_Impl, LOG_ERR, PAL_T("Failed to send auth response to client"))
 #if defined(CONFIG_ENABLE_DEBUG)
+#define trace_ProvReg_AccessDeniedRegFile(a0) trace_ProvReg_AccessDeniedRegFile_Impl(__FILE__, __LINE__, scs(a0))
+#else
+#define trace_ProvReg_AccessDeniedRegFile(a0) trace_ProvReg_AccessDeniedRegFile_Impl(0, 0, scs(a0))
+#endif
+FILE_EVENT1(20149, trace_ProvReg_AccessDeniedRegFile_Impl, LOG_ERR, PAL_T("Reg file %s access denied. It will be skipped by the server"), const char *)
+#if defined(CONFIG_ENABLE_DEBUG)
 #define trace__FindSubRequest_CannotFindKey(a0, a1, a2) trace__FindSubRequest_CannotFindKey_Impl(__FILE__, __LINE__, a0, a1, a2)
 #else
 #define trace__FindSubRequest_CannotFindKey(a0, a1, a2) trace__FindSubRequest_CannotFindKey_Impl(0, 0, a0, a1, a2)

--- a/Unix/provreg/provreg.c
+++ b/Unix/provreg/provreg.c
@@ -785,7 +785,10 @@ MI_Result ProvReg_Init(ProvReg* self, const char* directory)
                     reg = RegFile_New(regPath);
                     if (!reg)
                     {
-                        trace_ProvReg_SkipRegFile(scs(regPath));
+                        if (EACCES == errno)
+                            trace_ProvReg_AccessDeniedRegFile(scs(regPath));
+                        else
+                            trace_ProvReg_SkipRegFile(scs(regPath));
                         continue;
                     }
 


### PR DESCRIPTION
Customers were getting corrupted-file messages if omiengine was not able to read the provider registration files.  