### PR TITLE
Disable configuring of service manager for Docker env

### DIFF
--- a/Unix/installbuilder/datafiles/Linux.data
+++ b/Unix/installbuilder/datafiles/Linux.data
@@ -61,6 +61,10 @@ ResolveSystemdPaths()
 }
 
 RemoveGenericService() {
+    if [ -f /etc/.omi_disable_service_control ]; then
+        return 0
+    fi
+
     SERVICE=$1
     if [ -z "$SERVICE" ]; then
         echo "FATAL: RemoveGenericService requires parameter (service name)" 1>&2
@@ -135,43 +139,53 @@ StopOmiService() {
 }
 
 RemoveOmiService() {
+    if [ -f /etc/.omi_disable_service_control ]; then
+        StopOmiService
+        return 0
+    fi
+
     RemoveGenericService omid
     [ -f /etc/init.d/omid ] && rm /etc/init.d/omid
     [ -f /etc/init/omid.conf ] && rm /etc/init/omid.conf
 }
 
 ConfigureOmiService() {
-    echo "Configuring OMI service ..."
-    pidof systemd 1> /dev/null 2> /dev/null
-    if [ $? -eq 0 ]; then
-        # systemd
-        ResolveSystemdPaths
-        cp /opt/omi/bin/support/omid.systemd ${SYSTEMD_UNIT_DIR}/omid.service
-        /bin/systemctl daemon-reload
-        /bin/systemctl enable omid
-    elif [ -x /sbin/initctl -a -f /etc/init/networking.conf ]; then
-        # If we have /sbin/initctl, we have upstart.
-        # Note that the upstart script requires networking,
-        # so only use upstart if networking is controlled by upstart (not the case in RedHat 6)
-        cp /opt/omi/bin/support/omid.upstart /etc/init/omid.conf
+    # If the marker file /etc/.omi_disable_service_control exists,
+    # OMI will not be configured with service manager. This may be used in a container
+    # environment, where service manager does not work reliably.
+    if [ ! -f /etc/.omi_disable_service_control ]; then
+      echo "Configuring OMI service ..."
+      pidof systemd 1> /dev/null 2> /dev/null
+      if [ $? -eq 0 ]; then
+          # systemd
+          ResolveSystemdPaths
+          cp /opt/omi/bin/support/omid.systemd ${SYSTEMD_UNIT_DIR}/omid.service
+          /bin/systemctl daemon-reload
+          /bin/systemctl enable omid
+      elif [ -x /sbin/initctl -a -f /etc/init/networking.conf ]; then
+          # If we have /sbin/initctl, we have upstart.
+          # Note that the upstart script requires networking,
+          # so only use upstart if networking is controlled by upstart (not the case in RedHat 6)
+          cp /opt/omi/bin/support/omid.upstart /etc/init/omid.conf
 
-        # initctl registers it with upstart
-        initctl reload-configuration
-    else
-        cp /opt/omi/bin/support/omid.initd /etc/init.d/omid
+          # initctl registers it with upstart
+          initctl reload-configuration
+      else
+          cp /opt/omi/bin/support/omid.initd /etc/init.d/omid
 
-        if [ -x /usr/sbin/update-rc.d ]; then
-            update-rc.d omid defaults > /dev/null
-        elif [ -x /usr/lib/lsb/install_initd ]; then
-            /usr/lib/lsb/install_initd /etc/init.d/omid
-        elif [ -x /sbin/chkconfig ]; then
-            chkconfig --add omid > /dev/null
-        else
-            echo "Unrecognized Service Controller to configure OMI Service."
-            exit 1
-        fi
+          if [ -x /usr/sbin/update-rc.d ]; then
+              update-rc.d omid defaults > /dev/null
+          elif [ -x /usr/lib/lsb/install_initd ]; then
+              /usr/lib/lsb/install_initd /etc/init.d/omid
+          elif [ -x /sbin/chkconfig ]; then
+              chkconfig --add omid > /dev/null
+          else
+              echo "Unrecognized Service Controller to configure OMI Service."
+              exit 1
+          fi
+      fi
     fi
-
+    
     ${{SERVICE_CTL}} start
 }
 

--- a/Unix/installbuilder/service_scripts/service_control.linux
+++ b/Unix/installbuilder/service_scripts/service_control.linux
@@ -15,6 +15,11 @@
 #    restart:  Restart the OMI service via the service control manager
 #    reload:   Reload agent configuration
 #
+# If the special marker file /etc/.omi_disable_service_control exists,
+# OMI was not configured with service manager. This may be the case in a container
+# environment, where service manager does not work reliably. Instead of relying on
+# service manager to start/stop/restart OMI, we will instead invoke omiserver directly
+# to start/stop/restart OMI.  See also the file installbuilder/datafiles/linux.data.
 
 OMI_BIN=/opt/omi/bin/omiserver
 PIDFILE=/var/opt/omi/run/omiserver.pid
@@ -72,6 +77,11 @@ start_omi()
     is_omi_running
     [ $? -ne 0 ] && return
 
+    if [ -f /etc/.omi_disable_service_control ]; then
+        /opt/omi/bin/omiserver -d
+        return 0
+    fi
+
     # If systemd lives here, then we have a systemd unit file
     if pidof systemd 1> /dev/null 2> /dev/null; then
         /bin/systemctl start omid
@@ -97,6 +107,12 @@ stop_omi()
 {
     is_omi_running 
     if [ $? -ne 0 ]; then
+
+        if [ -f /etc/.omi_disable_service_control ]; then
+            /opt/omi/bin/omiserver -s
+            return 0
+        fi
+
         # If systemd lives here, then we have a systemd unit file
         if pidof systemd 1> /dev/null 2> /dev/null; then
             /bin/systemctl stop omid
@@ -125,6 +141,12 @@ restart_omi()
     if [ $? -eq 0 ]; then
         start_omi
         return
+    fi
+
+    if [ -f /etc/.omi_disable_service_control ]; then
+        stop_omi
+        start_omi
+        return 0
     fi
 
     # If systemd lives here, then we have a systemd unit file


### PR DESCRIPTION
On Docker systems, service manager may not work properly.  This commit introduces the environment variable OMI_DISABLE_SERVICE_START.  If set to non-null value, this will cause:

1.  The installer to not configure service manager.
2.  Disable /opt/omi/bin/service_control.

This means that on Docker systems where this is needed, one must manually start OMI after installation with command "sudo /opt/omi/bin/omiserver -d".  And run "sudo /opt/omi/bin/omiserver -s" to stop OMI before removing OMI package.