### PR TITLE
Add SSL cert checking options

### DIFF
--- a/Unix/common/MI.h
+++ b/Unix/common/MI.h
@@ -7845,6 +7845,56 @@ MI_INLINE MI_Result MI_DestinationOptions_GetTimeout(
 /*
 **=============================================================================
 **
+** MI_DestinationOptions_SetCertSelfSignedCheck()
+**
+**=============================================================================
+*/
+/* Check/skip Self-Signed check when doing SSL, default TRUE, check*/
+MI_INLINE MI_Result MI_DestinationOptions_SetCertSelfSignedCheck(
+    _Inout_ MI_DestinationOptions *options,
+         MI_Boolean check)
+{
+    if (options && options->ft)
+    {
+        return options->ft->SetNumber(options, MI_T("__MI_DESTINATIONOPTIONS_CERT_SELFSIGNED_CHECK"), check, 0);
+    }
+    else
+    {
+        return MI_RESULT_INVALID_PARAMETER;
+    }
+}
+
+/*
+**=============================================================================
+**
+** MI_DestinationOptions_GetCertSelfSignedCheck()
+**
+** Description
+**  Get Check/skip Self-Signed check when doing SSL
+**
+**=============================================================================
+*/
+MI_INLINE MI_Result MI_DestinationOptions_GetCertSelfSignedCheck(
+    _In_ const MI_DestinationOptions *options,
+    _Out_ MI_Boolean *check)
+{
+    if (options && options->ft)
+    {
+        MI_Uint32 value;
+        MI_Result result = options->ft->GetNumber(options, MI_T("__MI_DESTINATIONOPTIONS_CERT_SELFSIGNED_CHECK"), &value, 0, 0);
+        if (result == MI_RESULT_OK)
+            *check = (MI_Boolean) value;
+        return result;
+    }
+    else
+    {
+        return MI_RESULT_INVALID_PARAMETER;
+    }
+}
+
+/*
+**=============================================================================
+**
 ** MI_DestinationOptions_SetCertCACheck()
 **
 **=============================================================================

--- a/Unix/http/httpclient_private.h
+++ b/Unix/http/httpclient_private.h
@@ -108,6 +108,11 @@ typedef struct _HttpClient_SR_SocketData {
     char *contentType;
     Page *data;
 
+    /* Checking cert type options */
+    MI_Boolean skipselfsigncheck;    // Check/skip Self-Signed check when doing SSL
+    MI_Boolean skipcacheck;         // Check/skip CA check when doing SSL
+    MI_Boolean skipcncheck;         // Check/skip CN check when doing SSL
+    MI_Boolean skiprevocationcheck; // Check/skip Revocation check when doing SSL
 } HttpClient_SR_SocketData;
 
 struct _HttpClient {

--- a/Unix/tests/cli/test_cli.cpp
+++ b/Unix/tests/cli/test_cli.cpp
@@ -1585,7 +1585,7 @@ NitsTestWithSetup(TestOMICLI25_GetInstanceWsmanHttps, TestCliSetup)
     MI_Char buffer[1024];
 
     Stprintf(buffer, MI_COUNT(buffer),
-             MI_T("omicli gi --encryption https --hostname localhost -u test -p password --port %T root/test { MSFT_President Key 1 }"),
+             MI_T("omicli gi --encryption https --hostname localhost -u test -p password --port %T root/test { MSFT_President Key 1 } -skipselfsigncheck"),
              httpsPort);
 
     NitsCompare(Exec(buffer, out, err), 0, MI_T("Omicli error"));
@@ -1862,7 +1862,7 @@ NitsTestWithSetup(TestOMICLI25_GetInstanceWsmanNegotiateAuthSSL, TestCliSetupSud
         MI_Char buffer[1024];
 
         Stprintf(buffer, MI_COUNT(buffer),
-                 MI_T("omicli gi --encryption https --hostname %T --auth NegoWithCreds -u %T\\%T -p %T --port %T oop/requestor/test/cpp { MSFT_President Key 1 }"),
+                 MI_T("omicli gi --encryption https --hostname %T --auth NegoWithCreds -u %T\\%T -p %T --port %T oop/requestor/test/cpp { MSFT_President Key 1 } -skipselfsigncheck"),
                  hostFqdn,
                  ntlmDomain,
                  omiUser,
@@ -1898,7 +1898,7 @@ NitsTestWithSetup(TestOMICLI35_GetInstanceWsmanFailNegotiateAuthSSL, TestCliSetu
         MI_Char buffer[1024];
 
         Stprintf(buffer, MI_COUNT(buffer),
-                 MI_T("omicli gi --encryption https --hostname %T --auth NegoWithCreds -u %T\\%T -p BadPassword --port %T oop/requestor/test/cpp { MSFT_President Key 1 }"),
+                 MI_T("omicli gi --encryption https --hostname %T --auth NegoWithCreds -u %T\\%T -p BadPassword --port %T oop/requestor/test/cpp { MSFT_President Key 1 } -skipselfsigncheck"),
                  hostFqdn,
                  ntlmDomain,
                  omiUser,
@@ -2589,7 +2589,7 @@ NitsTestWithSetup(TestOMICLI38_GetInstanceWsmanKerberosAuthSSL, TestCliSetupSudo
         MI_Char buffer[1024];
 
         Stprintf(buffer, MI_COUNT(buffer),
-                 MI_T("omicli gi --encryption https --hostname %T --auth Kerberos -u %T\\%T -p %T --port %T oop/requestor/test/cpp { MSFT_President Key 1 }"),
+                 MI_T("omicli gi --encryption https --hostname %T --auth Kerberos -u %T\\%T -p %T --port %T oop/requestor/test/cpp { MSFT_President Key 1 } -skipselfsigncheck"),
                  hostFqdn,
                  krb5Realm,
                  omiUser,
@@ -2625,7 +2625,7 @@ NitsTestWithSetup(TestOMICLI39_GetInstanceWsmanFailKerberosAuthSSL, TestCliSetup
         MI_Char buffer[1024];
 
         Stprintf(buffer, MI_COUNT(buffer),
-                 MI_T("omicli gi --encryption https --hostname %T --auth Kerberos -u %T\\%T -p BadPassword --port %T oop/requestor/test/cpp { MSFT_President Key 1 }"),
+                 MI_T("omicli gi --encryption https --hostname %T --auth Kerberos -u %T\\%T -p BadPassword --port %T oop/requestor/test/cpp { MSFT_President Key 1 } -skipselfsigncheck"),
                  hostFqdn,
                  krb5Realm,
                  omiUser,

--- a/Unix/tests/http/test_httpclient.cpp
+++ b/Unix/tests/http/test_httpclient.cpp
@@ -844,6 +844,9 @@ NitsTestWithSetup(TestHttpClient_BasicOperations_https, TestHttpClientSetup)
         UT_ASSERT_EQUAL(MI_RESULT_OK,
                         MI_DestinationOptions_AddDestinationCredentials(miDestinationOptions, &miUserCredentials));
 
+        UT_ASSERT_EQUAL(MI_RESULT_OK,
+                        MI_DestinationOptions_SetCertSelfSignedCheck(miDestinationOptions, MI_FALSE));
+
         /* content to send to the client */
         s_response = "Test";
 
@@ -938,6 +941,9 @@ NitsTestWithSetup(TestHttpClient_BasicOperations_Der_https, TestHttpClientSetup)
         miUserCredentials.credentials.usernamePassword.password = TEST_PASSWORD;
         UT_ASSERT_EQUAL(MI_RESULT_OK,
                         MI_DestinationOptions_AddDestinationCredentials(miDestinationOptions, &miUserCredentials));
+
+        UT_ASSERT_EQUAL(MI_RESULT_OK,
+                        MI_DestinationOptions_SetCertSelfSignedCheck(miDestinationOptions, MI_FALSE));
 
         //HttpClientRequestHeaders headers = {
         //    header_strings,
@@ -1039,6 +1045,9 @@ NitsTestWithSetup(TestHttpClient_SSL_TLS, TestHttpClientSetup_SSL_TSL)
         UT_ASSERT_EQUAL(MI_RESULT_OK,
                         MI_DestinationOptions_SetSslOptions(miDestinationOptions, s_sslOptions));
 
+        UT_ASSERT_EQUAL(MI_RESULT_OK,
+                        MI_DestinationOptions_SetCertSelfSignedCheck(miDestinationOptions, MI_FALSE));
+
         /* content to send to the client */
         s_response = "Test";
 
@@ -1133,6 +1142,9 @@ NitsTestWithSetup(TestHttpClient_SSL_TLS_Mismatch, TestHttpClientSetup_SSL_TSL_M
 
         UT_ASSERT_EQUAL(MI_RESULT_OK,
                         MI_DestinationOptions_SetSslOptions(miDestinationOptions, s_sslOptions_client));
+
+        UT_ASSERT_EQUAL(MI_RESULT_OK,
+                        MI_DestinationOptions_SetCertSelfSignedCheck(miDestinationOptions, MI_FALSE));
 
         /* content to send to the client */
         s_response = "Test";
@@ -1393,6 +1405,9 @@ NitsTestWithSetup(TestHttpClient_BasicAuthDomain, TestHttpClientSetup)
                     MI_DestinationOptions_AddDestinationCredentials(miDestinationOptions, &miUserCredentials));
 
     UT_ASSERT_EQUAL(MI_RESULT_OK,
+                    MI_DestinationOptions_SetCertSelfSignedCheck(miDestinationOptions, MI_FALSE));
+
+    UT_ASSERT_EQUAL(MI_RESULT_OK,
         HttpClient_New_Connector2(&http, 0, "127.0.0.1", PORT + 1, MI_TRUE,
                                  _HttpClientCallbackOnConnect,
                                  _HttpClientCallbackOnStatus,
@@ -1470,6 +1485,9 @@ NitsTestWithSetup(TestHttpClient_HostHeader, TestHttpClientSetup)
                     MI_DestinationOptions_AddDestinationCredentials(miDestinationOptions, &miUserCredentials));
 
     UT_ASSERT_EQUAL(MI_RESULT_OK,
+                    MI_DestinationOptions_SetCertSelfSignedCheck(miDestinationOptions, MI_FALSE));
+
+    UT_ASSERT_EQUAL(MI_RESULT_OK,
         HttpClient_New_Connector2(&http, 0, "127.0.0.1", PORT + 1, MI_TRUE,
                                  _HttpClientCallbackOnConnect,
                                  _HttpClientCallbackOnStatus,
@@ -1543,6 +1561,9 @@ NitsTestWithSetup(TestHttpClient_BigBody, TestHttpClientSetup)
     miUserCredentials.credentials.usernamePassword.password = TEST_DOMAIN_PASSWD_W;
     UT_ASSERT_EQUAL(MI_RESULT_OK,
                     MI_DestinationOptions_AddDestinationCredentials(miDestinationOptions, &miUserCredentials));
+
+    UT_ASSERT_EQUAL(MI_RESULT_OK,
+                    MI_DestinationOptions_SetCertSelfSignedCheck(miDestinationOptions, MI_FALSE));
 
     UT_ASSERT_EQUAL(MI_RESULT_OK,
         HttpClient_New_Connector2(&http, 0, "127.0.0.1", PORT + 1, MI_TRUE,


### PR DESCRIPTION
@paulcallen , I add 4 new options for omicli "-skipselfsigncheck, -skipcacheck, -skipcncheck or -skiprevocationcheck", could you help to review this PR? thank you very much!

PowerShell only contains 3 options for https remoting: "-SkipCACheck,-SkipCNCheck,-SkipRevocationCheck", and "-skipselfsigncheck" is a new option that Pentest pointed out for notification of Self-Signed Certs.