### PR TITLE
Add pemfile and keyfile in omiserver.conf

### DIFF
--- a/Unix/installbuilder/conf/omiserver.conf
+++ b/Unix/installbuilder/conf/omiserver.conf
@@ -44,6 +44,17 @@ httpsport=0
 #logfile=/var/opt/omi/log/omiserver.log
 
 ##
+## The cert and its private key for TLS/SSL communication
+## pemfile -- The certificate to use for TLS/SSL communication
+##     For pemfile, its owner is root user
+## keyfile -- The private key that corresponds to the TLS/SSL certificate
+##     To modify keyfile, make sure its owner is `omi:omi`:
+##         run `chown omi:omi /yourpath/omikey.pem`
+## 
+#pemfile=/etc/opt/omi/ssl/omi.pem
+#keyfile=/etc/opt/omi/ssl/omikey.pem
+
+##
 ## This section is for security protocol settings
 ##   NoSSLv2: When it is true, the SSLv2 protocol is disabled.
 ##   NoSSLv3: When it is true, the SSLv3 protocol is disabled.


### PR DESCRIPTION
We can modify pemfile and keyfile in omiserver.conf, but need to change keyfile owner, so it can work fine if user generate it by root when enabling https.
@Microsoft/omi-devs , could you help to review it? thanks.