### PR TITLE
Bugfix: 'NoTLSv1_1' and 'NoTLSv1_2' don't work in omiserver.conf file…

### DIFF
--- a/Unix/http/httpcommon.h
+++ b/Unix/http/httpcommon.h
@@ -143,9 +143,9 @@ typedef enum _SSL_Options
     // Must be bits so these can be specified individually or together
     DISABLE_SSL_V2 = 0x01,
     DISABLE_SSL_V3 = 0x02,
-    DISABLE_TSL_V1_0 = 0x04,
-    DISABLE_TSL_V1_1 = 0x08,
-    DISABLE_TSL_V1_2 = 0x10,
+    DISABLE_TLS_V1_0 = 0x04,
+    DISABLE_TLS_V1_1 = 0x08,
+    DISABLE_TLS_V1_2 = 0x10,
     DISABLE_SSL_COMPRESSION = 0x20
 }
 SSL_Options;

--- a/Unix/miapi/Options.c
+++ b/Unix/miapi/Options.c
@@ -1282,11 +1282,11 @@ static MI_Result _GetDefaultOptionsFromConfigFile(MI_DestinationOptions *options
         {
             if (Strcasecmp(value, "true") == 0)
             {
-                sslOptions |= DISABLE_TSL_V1_0;
+                sslOptions |= DISABLE_TLS_V1_0;
             }
             else if (Strcasecmp(value, "false") == 0)
             {
-                sslOptions &= ~DISABLE_TSL_V1_0;
+                sslOptions &= ~DISABLE_TLS_V1_0;
             }
             else
             {
@@ -1298,11 +1298,11 @@ static MI_Result _GetDefaultOptionsFromConfigFile(MI_DestinationOptions *options
         {
             if (Strcasecmp(value, "true") == 0)
             {
-                sslOptions |= DISABLE_TSL_V1_1;
+                sslOptions |= DISABLE_TLS_V1_1;
             }
             else if (Strcasecmp(value, "false") == 0)
             {
-                sslOptions &= ~DISABLE_TSL_V1_1;
+                sslOptions &= ~DISABLE_TLS_V1_1;
             }
             else
             {
@@ -1314,11 +1314,11 @@ static MI_Result _GetDefaultOptionsFromConfigFile(MI_DestinationOptions *options
         {
             if (Strcasecmp(value, "true") == 0)
             {
-                sslOptions |= DISABLE_TSL_V1_2;
+                sslOptions |= DISABLE_TLS_V1_2;
             }
             else if (Strcasecmp(value, "false") == 0)
             {
-                sslOptions &= ~DISABLE_TSL_V1_2;
+                sslOptions &= ~DISABLE_TLS_V1_2;
             }
             else
             {

--- a/Unix/server/servercommon.c
+++ b/Unix/server/servercommon.c
@@ -734,11 +734,11 @@ void GetConfigFileOptions()
         {
             if (Strcasecmp(value, "true") == 0)
             {
-                s_optsPtr->sslOptions |= DISABLE_TSL_V1_0;
+                s_optsPtr->sslOptions |= DISABLE_TLS_V1_0;
             }
             else if (Strcasecmp(value, "false") == 0)
             {
-                s_optsPtr->sslOptions &= ~DISABLE_TSL_V1_0;
+                s_optsPtr->sslOptions &= ~DISABLE_TLS_V1_0;
             }
             else
             {
@@ -749,11 +749,11 @@ void GetConfigFileOptions()
         {
             if (Strcasecmp(value, "true") == 0)
             {
-                s_optsPtr->sslOptions |= DISABLE_TSL_V1_1;
+                s_optsPtr->sslOptions |= DISABLE_TLS_V1_1;
             }
             else if (Strcasecmp(value, "false") == 0)
             {
-                s_optsPtr->sslOptions &= ~DISABLE_TSL_V1_1;
+                s_optsPtr->sslOptions &= ~DISABLE_TLS_V1_1;
             }
             else
             {
@@ -764,11 +764,11 @@ void GetConfigFileOptions()
         {
             if (Strcasecmp(value, "true") == 0)
             {
-                s_optsPtr->sslOptions |= DISABLE_TSL_V1_2;
+                s_optsPtr->sslOptions |= DISABLE_TLS_V1_2;
             }
             else if (Strcasecmp(value, "false") == 0)
             {
-                s_optsPtr->sslOptions &= ~DISABLE_TSL_V1_2;
+                s_optsPtr->sslOptions &= ~DISABLE_TLS_V1_2;
             }
             else
             {

--- a/Unix/tests/http/test_httpclient.cpp
+++ b/Unix/tests/http/test_httpclient.cpp
@@ -55,8 +55,8 @@ static string s_password;
 static string s_hostHeader;
 static bool s_delayServerResponse = false;
 static MI_Uint32 s_sslOptions = DISABLE_SSL_V2 | DISABLE_SSL_V3;
-static MI_Uint32 s_sslOptions_client = DISABLE_SSL_V2 | DISABLE_SSL_V3 | DISABLE_TSL_V1_1 | DISABLE_TSL_V1_2;
-static MI_Uint32 s_sslOptions_server = DISABLE_SSL_V2 | DISABLE_TSL_V1_0 | DISABLE_TSL_V1_1 | DISABLE_TSL_V1_2;
+static MI_Uint32 s_sslOptions_client = DISABLE_SSL_V2 | DISABLE_SSL_V3 | DISABLE_TLS_V1_1 | DISABLE_TLS_V1_2;
+static MI_Uint32 s_sslOptions_server = DISABLE_SSL_V2 | DISABLE_TLS_V1_0 | DISABLE_TLS_V1_1 | DISABLE_TLS_V1_2;
 
 // received data
 static int s_httpCode;
@@ -274,7 +274,7 @@ NitsSetup(TestHttpClientSetup)
 }
 NitsEndSetup
 
-NitsSetup(TestHttpClientSetup_SSL_TSL)
+NitsSetup(TestHttpClientSetup_SSL_TLS)
 {
     IgnoreAuthCalls(1);
 
@@ -298,7 +298,7 @@ NitsSetup(TestHttpClientSetup_SSL_TSL)
 }
 NitsEndSetup
 
-NitsSetup(TestHttpClientSetup_SSL_TSL_Mismatch)
+NitsSetup(TestHttpClientSetup_SSL_TLS_Mismatch)
 {
     IgnoreAuthCalls(1);
 
@@ -329,14 +329,14 @@ NitsCleanup(TestHttpClientSetup)
 }
 NitsEndCleanup
 
-NitsCleanup(TestHttpClientSetup_SSL_TSL)
+NitsCleanup(TestHttpClientSetup_SSL_TLS)
 {
     _StopHTTP_Server();
     Sock_Stop();
 }
 NitsEndCleanup
 
-NitsCleanup(TestHttpClientSetup_SSL_TSL_Mismatch)
+NitsCleanup(TestHttpClientSetup_SSL_TLS_Mismatch)
 {
     _StopHTTP_Server();
     Sock_Stop();
@@ -1000,7 +1000,7 @@ NitsTestWithSetup(TestHttpClient_BasicOperations_Der_https, TestHttpClientSetup)
 }
 NitsEndTest
 
-NitsTestWithSetup(TestHttpClient_SSL_TLS, TestHttpClientSetup_SSL_TSL)
+NitsTestWithSetup(TestHttpClient_SSL_TLS, TestHttpClientSetup_SSL_TLS)
 {
     NitsDisableFaultSim;
 
@@ -1095,7 +1095,7 @@ NitsTestWithSetup(TestHttpClient_SSL_TLS, TestHttpClientSetup_SSL_TSL)
 }
 NitsEndTest
 
-NitsTestWithSetup(TestHttpClient_SSL_TLS_Mismatch, TestHttpClientSetup_SSL_TSL_Mismatch)
+NitsTestWithSetup(TestHttpClient_SSL_TLS_Mismatch, TestHttpClientSetup_SSL_TLS_Mismatch)
 {
     NitsDisableFaultSim;
 


### PR DESCRIPTION
- Bugfix: 'NoTLSv1_1' and 'NoTLSv1_2' don't work in omiserver.conf file 
- rename improper variables