### PR TITLE
Support MS-WSMAN session cookies over HTTP

### DIFF
--- a/Unix/base/messages.h
+++ b/Unix/base/messages.h
@@ -195,6 +195,13 @@ struct _Message
      */
     MI_Char *shellId;
 
+    /* Message's destructor [opt]
+        'Release' will call dtor (if set) right before destroying the message */
+    void (*dtor)(Message* message, void* callbackData);
+
+    /* Data passed as 2nd argument of 'dtor' */
+    void* dtorData;
+
     /*
         For http transport operations that go through a load balancer,
         we need the MS_WSMAN cookie for subsequent requests.
@@ -202,13 +209,6 @@ struct _Message
         _HttpProcessRequest.
     */
     MI_Char *sessionCookie;
-
-    /* Message's destructor [opt]
-        'Release' will call dtor (if set) right before destroying the message */
-    void (*dtor)(Message* message, void* callbackData);
-
-    /* Data passed as 2nd argument of 'dtor' */
-    void* dtorData;
 };
 
 Message* __Message_New(

--- a/Unix/base/messages.h
+++ b/Unix/base/messages.h
@@ -195,6 +195,14 @@ struct _Message
      */
     MI_Char *shellId;
 
+    /*
+        For http transport operations that go through a load balancer,
+        we need the MS_WSMAN cookie for subsequent requests.
+        The value is retrieved from the HttpHeaders passed to
+        _HttpProcessRequest.
+    */
+    MI_Char *sessionCookie;
+
     /* Message's destructor [opt]
         'Release' will call dtor (if set) right before destroying the message */
     void (*dtor)(Message* message, void* callbackData);

--- a/Unix/http/httpclient.c
+++ b/Unix/http/httpclient.c
@@ -1538,6 +1538,12 @@ static MI_Boolean _RequestCallback(
             handler->hostname = NULL;
         }
 
+        if (handler->sessionCookie)
+        {
+            PAL_Free(handler->sessionCookie);
+            handler->sessionCookie = NULL;
+        }
+
         if (handler->ssl)
             SSL_free(handler->ssl);
 
@@ -2923,12 +2929,6 @@ MI_Result HttpClient_Delete(
 
     /* Clear magic number */
     self->magic = 0xDDDDDDDD;
-
-    if (self->connector->sessionCookie)
-    {
-        PAL_Free(self->connector->sessionCookie);
-        self->connector->sessionCookie = NULL;
-    }
 
     /* Free self pointer */
     PAL_Free(self);

--- a/Unix/http/httpclient_private.h
+++ b/Unix/http/httpclient_private.h
@@ -83,6 +83,9 @@ typedef struct _HttpClient_SR_SocketData {
     char *password;
     MI_Uint32 passwordLen;
 
+    char *sessionCookie;        // The MS_WSMAN session cookie header value to send with the next request.
+                                // This is retrieved from the MI_DestinationOptions
+
     void *authContext;          // gss_context_t
     void *targetName;           // gss_name_t
     void *cred;                 // gss_cred_id_t
@@ -134,7 +137,7 @@ typedef enum _Http_CallbackResult {
 } Http_CallbackResult;
 
 Page *_CreateHttpHeader(const char *verb, const char *uri, const char *contentType,
-                        const char *authHeader, const char *hostHeader, HttpClientRequestHeaders *extraHeaders, size_t size);
+                        const char *authHeader, const char *hostHeader, const char *sessionCookie, HttpClientRequestHeaders *extraHeaders, size_t size);
 
 Http_CallbackResult HttpClient_RequestAuthorization(_In_ struct _HttpClient_SR_SocketData *self,
                                                     _Out_ const char **pAuthHeader);

--- a/Unix/http/httpclientauth.c
+++ b/Unix/http/httpclientauth.c
@@ -2873,7 +2873,7 @@ Http_CallbackResult HttpClient_IsAuthorized(_In_ struct _HttpClient_SR_SocketDat
 
                 if (self->verb)
                 {
-                    self->sendHeader =  _CreateHttpHeader(self->verb, self->uri, self->contentType, NULL, self->hostHeader, NULL, self->data? self->data->u.s.size: 0);
+                    self->sendHeader =  _CreateHttpHeader(self->verb, self->uri, self->contentType, NULL, self->hostHeader, NULL, NULL, self->data? self->data->u.s.size: 0);
                     self->sendPage   =  self->data;
 
                     self->verb        = NULL;
@@ -2923,7 +2923,7 @@ Http_CallbackResult HttpClient_IsAuthorized(_In_ struct _HttpClient_SR_SocketDat
                      if (self->verb)
                      {
                          self->sendHeader =  _CreateHttpHeader(self->verb, self->uri, self->contentType, NULL, self->hostHeader, 
-                                                               NULL, self->data? self->data->u.s.size: 0);
+                                                               NULL, NULL, self->data? self->data->u.s.size: 0);
                          self->sendPage   =  self->data;
 
                          self->verb        = NULL;

--- a/Unix/miapi/InteractionProtocolHandler.c
+++ b/Unix/miapi/InteractionProtocolHandler.c
@@ -249,7 +249,7 @@ static void InteractionProtocolHandler_UpdateSessionCookie(_In_ InteractionProto
     const MI_Char *endCookie = Tcschr(newSessionCookie, MI_T(';'));
     if (endCookie)
     {
-        newLen = endCookie -  newSessionCookie;
+        newLen = endCookie -  newSessionCookie + 1;
     }
     else
     {

--- a/Unix/miapi/InteractionProtocolHandler.c
+++ b/Unix/miapi/InteractionProtocolHandler.c
@@ -999,8 +999,10 @@ done:
 
             Lock_Acquire(&session->lock);
             if (session->sessionCookie)
+            {
                 PAL_Free(session->sessionCookie);
                 session->sessionCookie = NULL;
+            }
             Lock_Release(&session->lock);
 
             PAL_Free(session);


### PR DESCRIPTION
This change adds support for detecting and using the MS_WSMAN session cookie.  This is needed to maintain connections to sites behind a load balancer, such as office 365.

The change is in the following layers, 
* httpclient (httpclient.c, httpclient_private.h, httpclientauth.c), 
* wsmanclient (wsmanclient.c)
* Interaction protocol (InteractionProtocolHandler.c)
* Message.h (updates the base Message structure to support a session cookie)

The logic starts at the response from the target containing a Set-Cookie: MS-WSMAN:* header.  This is handled by the wsmanclient layer which detects and passes up using the base Message structure (typically via PostInstance)

InteractionProtocolHandler.c is responsible for detecting changes to the cookie value and saving it for the next request sent to the server. At that point, the session cookie is added to the MI_DestinationOptions passed down to create the connection.  Note that not all messages sent from wsmanclient to interaction protocol contains a session cookie.

Finally, the http layer is responsible for adding the Cookie header on the next request.
