### PR TITLE
Support MS-WSMAN session cookies over HTTP

### DIFF
--- a/Unix/base/messages.h
+++ b/Unix/base/messages.h
@@ -201,6 +201,14 @@ struct _Message
 
     /* Data passed as 2nd argument of 'dtor' */
     void* dtorData;
+
+    /*
+        For http transport operations that go through a load balancer,
+        we need the MS_WSMAN cookie for subsequent requests.
+        The value is retrieved from the HttpHeaders passed to
+        _HttpProcessRequest.
+    */
+    MI_Char *sessionCookie;
 };
 
 Message* __Message_New(

--- a/Unix/http/httpclient.c
+++ b/Unix/http/httpclient.c
@@ -1538,6 +1538,12 @@ static MI_Boolean _RequestCallback(
             handler->hostname = NULL;
         }
 
+        if (handler->sessionCookie)
+        {
+            PAL_Free(handler->sessionCookie);
+            handler->sessionCookie = NULL;
+        }
+
         if (handler->ssl)
             SSL_free(handler->ssl);
 
@@ -1920,6 +1926,7 @@ Page* _CreateHttpHeader(
     const char* contentType,
     const char* authHeader,
     const char* hostHeader,
+    const char* sessionCookie,
     HttpClientRequestHeaders *extraHeaders,
     size_t size)
 {
@@ -1927,6 +1934,7 @@ Page* _CreateHttpHeader(
     size_t pageSize = 0;
     int r;
     char* p;
+    size_t sessionCookieLen = 0;
 
     static const char HTTP_PROTOCOL_HEADER[]     = "HTTP/1.1";
     static const char HTTP_PROTOCOL_HEADER_LEN = MI_COUNT(HTTP_PROTOCOL_HEADER)-1;
@@ -1940,6 +1948,9 @@ Page* _CreateHttpHeader(
     static const char CONNECTION_KEEPALIVE[] = "Keep-Alive";
     static const char CONNECTION_KEEPALIVE_LEN = MI_COUNT(CONNECTION_KEEPALIVE)-1;
 
+    static const char COOKIE_HEADER[] = "Cookie: ";
+    #define COOKIE_HEADER_LEN (MI_COUNT(COOKIE_HEADER)-1)
+
     pageSize += Strlen(hostHeader) + 2;
     if (extraHeaders)
     {
@@ -1948,6 +1959,12 @@ Page* _CreateHttpHeader(
         {
             pageSize += Strlen(extraHeaders->data[i]) + 2;
         }
+    }
+
+    if (sessionCookie)
+    {
+        sessionCookieLen = Strlen(sessionCookie);
+        pageSize += sessionCookieLen + COOKIE_HEADER_LEN + 2;
     }
 
     /* calculate approximate page size */
@@ -2055,6 +2072,20 @@ Page* _CreateHttpHeader(
         r = (int)Strlcpy(p, hostHeader, pageSize);
         p += r;
         pageSize -= r;
+    }
+
+    if (sessionCookie)
+    {
+        memcpy(p, COOKIE_HEADER, COOKIE_HEADER_LEN);
+        p += COOKIE_HEADER_LEN;
+        
+        memcpy(p, sessionCookie, sessionCookieLen);
+        p += sessionCookieLen;
+
+        memcpy(p, "\r\n", 2);
+        p += 2;
+        
+        pageSize -= COOKIE_HEADER_LEN + sessionCookieLen + 2;
     }
 
     if (extraHeaders)
@@ -2195,6 +2226,7 @@ MI_Result _UnpackDestinationOptions(
     _Out_opt_ char **pTrustedCertsDir,
     _Out_opt_ char **pCertFile,
     _Out_opt_ char **pPrivateKeyFile,
+    _Out_opt_ const MI_Char **pSessionCookie,
     SSL_Options *sslOptions)
 {
   static const MI_Char   AUTH_NAME_BASIC[]   = MI_AUTH_TYPE_BASIC;
@@ -2253,6 +2285,11 @@ MI_Result _UnpackDestinationOptions(
         goto Done;
     }         
 
+    if (MI_DestinationOptions_GetString(pDestOptions, MI_T("MS_WSMAN_SESSION_COOKIE"), pSessionCookie, 0)
+        != MI_RESULT_OK)
+        {
+            *pSessionCookie = NULL;
+        }
 
     /* First delivery. pAuthType. We convert the string into an enum */
     
@@ -2584,6 +2621,7 @@ MI_Result HttpClient_New_Connector2(
     char *username = NULL;
     char *user_domain = NULL;
     char *password    = NULL;
+    const MI_Char *sessionCookie = NULL;
     MI_Uint32 password_len = 0;
     SSL_Options sslOptions;
 
@@ -2614,7 +2652,7 @@ MI_Result HttpClient_New_Connector2(
     if (pDestOptions)
     {
         r = _UnpackDestinationOptions(pDestOptions, &authtype, &username, &password, &password_len, &privacy, &transport,
-                                      &trusted_certs_dir, &cert_file, &private_key_file, &sslOptions);
+                                      &trusted_certs_dir, &cert_file, &private_key_file, &sessionCookie, &sslOptions);
 
         if (MI_RESULT_OK != r)
         {
@@ -2695,6 +2733,10 @@ MI_Result HttpClient_New_Connector2(
         client->connector->readyToSend  = FALSE;
         client->connector->negoFlags    = FALSE;
         client->connector->hostname     = PAL_Strdup(host);
+        if (sessionCookie)
+        {
+            client->connector->sessionCookie = PAL_Strdup(sessionCookie);
+        }
 
         static const char HOST_HEADER[] = "Host: ";
         int host_header_size_required = strlen(host)+sizeof(HOST_HEADER)+10; // 10 == max length of port plus CRLF
@@ -3110,7 +3152,7 @@ MI_Result HttpClient_StartRequestV2(
 
     /* create header page */
     client->connector->sendHeader =
-        _CreateHttpHeader(verb, uri, contentType, auth_header, client->connector->hostHeader, extraHeaders, (data && *data) ? (*data)->u.s.size : 0);
+        _CreateHttpHeader(verb, uri, contentType, auth_header, client->connector->hostHeader, client->connector->sessionCookie, extraHeaders, (data && *data) ? (*data)->u.s.size : 0);
 
     if (data != NULL)
     {

--- a/Unix/http/httpclient_private.h
+++ b/Unix/http/httpclient_private.h
@@ -83,6 +83,9 @@ typedef struct _HttpClient_SR_SocketData {
     char *password;
     MI_Uint32 passwordLen;
 
+    char *sessionCookie;        // The MS_WSMAN session cookie header value to send with the next request.
+                                // This is retrieved from the MI_DestinationOptions
+
     void *authContext;          // gss_context_t
     void *targetName;           // gss_name_t
     void *cred;                 // gss_cred_id_t
@@ -134,7 +137,7 @@ typedef enum _Http_CallbackResult {
 } Http_CallbackResult;
 
 Page *_CreateHttpHeader(const char *verb, const char *uri, const char *contentType,
-                        const char *authHeader, const char *hostHeader, HttpClientRequestHeaders *extraHeaders, size_t size);
+                        const char *authHeader, const char *hostHeader, const char *sessionCookie, HttpClientRequestHeaders *extraHeaders, size_t size);
 
 Http_CallbackResult HttpClient_RequestAuthorization(_In_ struct _HttpClient_SR_SocketData *self,
                                                     _Out_ const char **pAuthHeader);

--- a/Unix/http/httpclientauth.c
+++ b/Unix/http/httpclientauth.c
@@ -2873,7 +2873,7 @@ Http_CallbackResult HttpClient_IsAuthorized(_In_ struct _HttpClient_SR_SocketDat
 
                 if (self->verb)
                 {
-                    self->sendHeader =  _CreateHttpHeader(self->verb, self->uri, self->contentType, NULL, self->hostHeader, NULL, self->data? self->data->u.s.size: 0);
+                    self->sendHeader =  _CreateHttpHeader(self->verb, self->uri, self->contentType, NULL, self->hostHeader, NULL, NULL, self->data? self->data->u.s.size: 0);
                     self->sendPage   =  self->data;
 
                     self->verb        = NULL;
@@ -2923,7 +2923,7 @@ Http_CallbackResult HttpClient_IsAuthorized(_In_ struct _HttpClient_SR_SocketDat
                      if (self->verb)
                      {
                          self->sendHeader =  _CreateHttpHeader(self->verb, self->uri, self->contentType, NULL, self->hostHeader, 
-                                                               NULL, self->data? self->data->u.s.size: 0);
+                                                               NULL, NULL, self->data? self->data->u.s.size: 0);
                          self->sendPage   =  self->data;
 
                          self->verb        = NULL;


### PR DESCRIPTION
This change adds support for detecting and using the MS_WSMAN session cookie. This is needed to maintain connections to sites behind a load balancer, such as office 365.

The change is in the following layers,

httpclient (httpclient.c, httpclient_private.h, httpclientauth.c),
wsmanclient (wsmanclient.c)
Interaction protocol (InteractionProtocolHandler.c)
Message.h (updates the base Message structure to support a session cookie)
The logic starts at the response from the target containing a Set-Cookie: MS-WSMAN:* header. This is handled by the wsmanclient layer which detects and passes up using the base Message structure (typically via PostInstance)

InteractionProtocolHandler.c is responsible for detecting changes to the cookie value and saving it for the next request sent to the server. At that point, the session cookie is added to the MI_DestinationOptions passed down to create the connection. Note that not all messages sent from wsmanclient to interaction protocol contains a session cookie.

Finally, the http layer is responsible for adding the Cookie header on the next request.