### PR TITLE
Fix stale operation instance for connection error paths

### DIFF
--- a/Unix/miapi/InteractionProtocolHandler.c
+++ b/Unix/miapi/InteractionProtocolHandler.c
@@ -1467,8 +1467,8 @@ done:
         if (operation)
         {
             operation->req = NULL;
-            _Operation_SendFinalResult_Internal(operation);
             /* This causes InteractionProtocolHandler_Operation_Strand_Finish to be called and will delete operation */
+            _Operation_SendFinalResult_Internal(operation);
         }
 
         memset(_operation, 0, sizeof(*_operation));


### PR DESCRIPTION
Fix https://github.com/Microsoft/omi/issues/502

This change adds a reference count to the InteractionProtcolHandler_Operation structure to address the race condition between InteractionProtocolHandler_Operation_Strand_Finish and InteractionProtocolHandler_Session_CommonInstanceCode.

For connection errors, the operation instance was being freed before returning to InteractionProtocolHandler_Session_Connect. This resulted in Session_Connect referencing a stale instance pointer and, later, a double free to occur on the operation instance.

The fix is as follows:
1: Set the reference count to 2 when the operation created
* 1 refcount ensures the lifetime is valid until control is returned to InteractionProtocolHandler_Session_CommonInstanceCode
* 1 refcount is for Strand_Finish to use when releasing the operation.

2: Remove the PAL_Free(operation) call from the error path in InteractionProtocolHandler_Operation_Close. This was causing a double free in error paths.

For error paths, the final release occurs in CommonInstanceCode since Finish has already been called.
For success paths, the final release typically occurs in Finish sometime after CommonInstanceCode has released it's reference.