### PR TITLE
Handle session cookies to office365.com

### DIFF
--- a/Unix/base/messages.h
+++ b/Unix/base/messages.h
@@ -201,14 +201,6 @@ struct _Message
 
     /* Data passed as 2nd argument of 'dtor' */
     void* dtorData;
-
-    /*
-        For http transport operations that go through a load balancer,
-        we need the MS_WSMAN cookie for subsequent requests.
-        The value is retrieved from the HttpHeaders passed to
-        _HttpProcessRequest.
-    */
-    MI_Char *sessionCookie;
 };
 
 Message* __Message_New(

--- a/Unix/http/GNUmakefile
+++ b/Unix/http/GNUmakefile
@@ -8,7 +8,8 @@ SOURCES = \
     http.c \
     httpauth.c \
     httpclient.c \
-    httpclientauth.c 
+    httpclientauth.c \
+    sessionmap.c
 
 INCLUDES = $(TOP) $(TOP)/common
 

--- a/Unix/http/httpclient.h
+++ b/Unix/http/httpclient.h
@@ -219,7 +219,6 @@ MI_Result HttpClient_StartRequestV2(
               Page** data,
               const Probable_Cause_Data **cause);
 
-
 /*
     Sets timeout for http connection.
     Default timeout is 1 minute
@@ -242,6 +241,16 @@ MI_Result HttpClient_Run(
 Selector *HttpClient_GetSelector(HttpClient *self);
 
 MI_Result HttpClient_WakeUpSelector(HttpClient *self, MI_Uint64 whenTime);
+
+/*
+    Removes a session id from the internal session map
+    Parameters:
+    sessionId - the string session id to remove.
+    returns:
+        0 on success, -1 if the session id was not found.
+*/
+int HttpClient_RemoveSession(_In_ const char * sessionId);
+
 END_EXTERNC
 
 #endif /* _omi_http_httpclient_h */

--- a/Unix/http/httpclient_private.h
+++ b/Unix/http/httpclient_private.h
@@ -83,8 +83,7 @@ typedef struct _HttpClient_SR_SocketData {
     char *password;
     MI_Uint32 passwordLen;
 
-    char *sessionCookie;        // The MS_WSMAN session cookie header value to send with the next request.
-                                // This is retrieved from the MI_DestinationOptions
+    const char* sessionId;            // The wsman session id
 
     void *authContext;          // gss_context_t
     void *targetName;           // gss_name_t
@@ -127,6 +126,7 @@ struct _HttpClient {
     Probable_Cause_Data      *probableCause;
 
     MI_Boolean internalSelectorUsed;
+    char* sessionId;   // Passed in at creation time.
 };
 
 /* helper functions result */

--- a/Unix/http/sessionmap.c
+++ b/Unix/http/sessionmap.c
@@ -1,0 +1,323 @@
+#include "sessionmap.h"
+#include <pal/memory.h>
+#include <pal/strings.h>
+#include <common.h>
+
+#define ENABLE_TRACING 1
+#define FORCE_TRACING 1
+
+#ifdef ENABLE_TRACING
+# define TRACING_LEVEL 4
+#include <base/result.h>
+#include <base/logbase.h>
+#include <base/log.h>
+#define LOGE2 __LOGE
+#define LOGW2 __LOGW
+#define LOGD2 __LOGD
+#else
+# define LOGE2(a)
+# define LOGW2(a)
+# define LOGD2(a)
+# define LOGX2(a)
+#endif
+
+typedef struct _SessionBucket
+{
+    struct _SessionBucket *next;// HashMap usage
+    const char* sessionId;      // WS_MAN Session Id 
+    size_t hash;                // Hash value for sessionId
+    char* cookie;               // MS-WSMAN Cookie
+                                // allocated on creation and update.
+                                // owned by the bucket
+} SessionBucket;
+
+#define SESSIONID_HASH_SEED 1313038763
+
+static size_t _SessionId_Hash(_In_z_ const char* sessionId)
+{
+    size_t hash = SESSIONID_HASH_SEED;
+    if (sessionId)
+    {
+        const char*p = sessionId;
+        while(*p)
+        {
+            // From strset.c
+            hash ^= ((hash << 5) + *p + (hash >> 2));
+            p++;
+        }
+    }
+    return hash;
+}
+
+static size_t _SessionBucket_GetHash(_In_ const HashBucket *b)
+{
+    const SessionBucket *bucket = (const SessionBucket*) b;
+    return bucket->hash;
+}
+
+static int _SessionBucket_Equal(_In_ const HashBucket* b1, _In_ const HashBucket* b2)
+{
+    const SessionBucket* bucket1 = (const SessionBucket*) b1;
+    const SessionBucket* bucket2 = (const SessionBucket*) b2;
+    return 
+    (
+        bucket1->hash == bucket2->hash
+        &&
+        strcmp(bucket1->sessionId, bucket2->sessionId) == 0
+    );
+}
+
+static void _SessionBucket_Release(HashBucket *b)
+{
+    if (b)
+    {
+        SessionBucket* bucket = (SessionBucket*) b;
+        if (bucket->cookie)
+        {
+            PAL_Free(bucket->cookie);           
+        }
+        PAL_Free(bucket);
+    }
+}
+
+/*
+    Allocates and inserts a new sessionid entry.
+    Parameters:
+        self - the SessionMap
+        sessionId - the session id
+        hash - the has value for the session id produced by _SessionId_Hash
+
+    NOTE: The caller must aquire a WriteLock.
+*/
+static SessionBucket* _SessionBucket_New(SessionMap *self, _In_z_ const char* sessionId, size_t hash)
+{
+    // WriteLock expected by the caller.
+    SessionBucket* bucket = NULL;
+    if (sessionId) do // while (FALSE)
+    {
+        size_t keyLen = strlen(sessionId);
+        size_t size = sizeof(SessionBucket) + keyLen + 1;
+        bucket = PAL_Malloc(size);
+        if (NULL == bucket)
+        {
+            LOGE2((ZT("_SessionBucket_New - failed to allocate bucket: %s"), sessionId));
+            break;
+        }
+
+        char* clone = (char*) (((unsigned char*) bucket) + sizeof(SessionBucket));
+        strcpy(clone, sessionId);
+        bucket->sessionId = clone;
+        bucket->hash = hash;
+        bucket->cookie = NULL;
+        bucket->next = NULL;
+
+        if (HashMap_Insert (&self->map, (HashBucket*) bucket) != 0)
+        {
+            // Not expecting the bucket to already exist.
+            _SessionBucket_Release((HashBucket*) bucket);
+            bucket = NULL;
+            LOGE2((ZT("_SessionBucket_New - sessionId already exists: %s"), sessionId));
+            break;
+        }
+        LOGD2((ZT("SessionBucket_New - added new session id: %s"), sessionId));
+    } while (0);
+
+    return bucket;
+}
+
+static BOOL _SessionMap_IsValid(SessionMap* self)
+{
+    if (NULL == self)
+    {
+        return FALSE;
+    }
+
+    ReadWriteLock_AcquireWrite(&self->lock);
+
+    int result = 0;
+    if (SESSIONID_HASH_SEED != self->state)
+    {
+        const size_t numItems = 64;
+
+        result = HashMap_Init(&self->map, 
+            numItems, 
+            _SessionBucket_GetHash, 
+            _SessionBucket_Equal, 
+            _SessionBucket_Release);
+
+        if (0 == result)
+        {
+            LOGD2((ZT("_SessionMap_IsValid - SessionMap initialized.")));
+            self->state = SESSIONID_HASH_SEED;
+        }
+        else
+        {
+            LOGE2((ZT("_SessionMap_IsValid - Could not initialize the HashMap.")));
+        }
+    }
+    ReadWriteLock_ReleaseWrite(&self->lock);
+
+    return (0 == result);
+}
+
+SessionBucket* _SessionMap_Find(_In_ SessionMap* self, _Out_ SessionBucket* keyBucket, _In_z_ const char* sessionId)
+{
+    // Read Lock expected.
+    keyBucket->sessionId = sessionId;
+    keyBucket->hash = _SessionId_Hash(sessionId);
+    HashBucket* bucket = HashMap_Find(&self->map, (const HashBucket*) keyBucket);
+
+    if (bucket)
+    {
+        return (SessionBucket*) bucket;
+    }
+    return NULL;
+}
+
+/*
+        Public functions
+*/
+
+/*
+    NOTE: Currently, there's no clear place to call this.
+    The result is the HasMap will be reported as a leak for the 
+    allocated hash array.
+
+int SessionMap_Empty(_Out_ SessionMap *self)
+{
+    if (NULL == self || SESSIONID_HASH_SEED != self->state)
+    {
+        return -1;
+    }
+    ReadWriteLock_AcquireWrite(&self->lock);
+
+    self->state = 0;
+
+    HashMap_Destroy(&self->map);
+    memset(&self->map, 0, sizeof(HashMap));
+
+    ReadWriteLock_ReleaseWrite(&self->lock);
+
+    return 0;
+}
+*/
+
+
+int SessionMap_SetCookie(_In_ SessionMap* self, 
+     _In_z_ const char* sessionId,
+     _In_opt_z_ const char* sessionCookie)
+{
+    if (!_SessionMap_IsValid(self) || NULL == sessionId)
+    {
+        return -1;
+    }
+
+    SessionBucket keyBucket = {0};
+    int result =0;
+
+    ReadWriteLock_AcquireWrite(&self->lock);
+    SessionBucket* item = _SessionMap_Find(self, &keyBucket, sessionId);
+
+    do 
+    {
+        if (NULL == item)
+        {
+            if (NULL == sessionCookie)
+            {
+                // Nothing to do
+                break;
+            }
+            item = _SessionBucket_New(self, sessionId, keyBucket.hash);
+            if (NULL == item)
+            {
+                result = -1;
+                break;
+            }
+        }
+        else if (NULL == sessionCookie)
+        {
+            PAL_Free(item->cookie);
+            item->cookie = NULL;
+            LOGD2((ZT("SessionMap_SetCookie - Cleared cookie for session id %s"), sessionId));
+            break;
+        }
+
+        size_t newLen = 0;
+        const char* endCookie = Strchr(sessionCookie, ';');
+        if (endCookie)
+        {
+            newLen = endCookie - sessionCookie + 1;
+        }
+        else
+        {
+            newLen = Strlen(sessionCookie);
+        }
+
+        if (NULL == item->cookie || Strncmp(sessionCookie, item->cookie, newLen) != 0)
+        {
+            PAL_Free(item->cookie);
+            item->cookie = PAL_Malloc(newLen + 1);
+            if (NULL == item->cookie)
+            {
+                result = -1;
+                break;
+            }
+            Strlcpy(item->cookie, sessionCookie, newLen);
+            item->cookie[newLen] = 0;
+            LOGD2((ZT("SessionMap_SetCookie - Set new cookie for session id %s: %s"), sessionId, item->cookie));
+        }
+    } while(0);
+
+    ReadWriteLock_ReleaseWrite(&self->lock);
+
+    return result;
+}
+
+const char* SessionMap_GetCookie(_In_ SessionMap* self, _In_z_ const char* sessionId)
+{
+    const char* result = NULL;
+
+    if (sessionId && _SessionMap_IsValid(self))
+    {
+        SessionBucket keyBucket = {0};
+    
+        ReadWriteLock_AcquireRead(&self->lock);
+
+        const SessionBucket* item = _SessionMap_Find(self, &keyBucket, sessionId);
+        if (NULL != item)
+        {
+            result = item->cookie;
+        }
+
+        ReadWriteLock_ReleaseRead(&self->lock);
+    }
+    return result;
+}
+
+int SessionMap_Remove(_In_ SessionMap* self, _In_z_ const char* sessionId)
+{
+    if (NULL == sessionId || !_SessionMap_IsValid(self))
+    {
+        return -1;
+    }
+
+    ReadWriteLock_AcquireWrite(&self->lock);
+
+    SessionBucket keyBucket = {0};
+    keyBucket.sessionId = sessionId;
+    keyBucket.hash = _SessionId_Hash(sessionId);
+
+    int result = HashMap_Remove(&self->map, (const HashBucket*) &keyBucket);
+    if (result != 0)
+    {
+        LOGW2((ZT("SessionMap_Remove - Failed: %s"), sessionId));    
+    }
+    else
+    {
+        LOGD2((ZT("SessionMap_Remove - Removed: %s"), sessionId));    
+    }
+
+    ReadWriteLock_ReleaseWrite(&self->lock);
+    return result;
+}
+

--- a/Unix/http/sessionmap.h
+++ b/Unix/http/sessionmap.h
@@ -1,0 +1,64 @@
+/*
+**==============================================================================
+**
+** Copyright (c) Microsoft Corporation. All rights reserved. See file LICENSE
+** for license information.
+**
+**==============================================================================
+*/
+#ifndef _omi_sessionmap_h
+#define _omi_sessionmap_h
+
+#include <pal/lock.h>
+#include <pal/hashmap.h>
+
+typedef struct _SessionMap
+{
+    size_t state;       // Set to SESSIONID_HASH_SEED when valid.
+    ReadWriteLock lock; // serialize access to the map
+    HashMap map;
+} SessionMap;
+
+// Used to initialize a static SessionMap
+#define SESSIONMAP_INIT {0, READWRITELOCK_INITIALIZER, {0}}
+
+/*
+    Sets the session cookie for a session id.
+
+    This function adds the session id to the map if it doesn't already exist.
+    To clear the session cookie, pass a NULL pointer. Clearning 
+    the session cookie does not remove the session from the SessionMap.
+
+    Returns:
+        0  if hte session cookie was updated.
+        -1 if the SessionMap is NULL or invalid.
+*/
+int SessionMap_SetCookie(_In_ SessionMap* self, 
+     _In_z_ const char* sessionId,
+     _In_opt_z_ const char* sessionCookie);
+
+/*
+    Gets the session cookie for a session id.
+
+    Returns: 
+        The string cookie on success
+        A NULL if the session id is not found or,
+            the session does not have an associated cookie or,
+            the SessionMap is NULL or invalid.
+*/
+const char* SessionMap_GetCookie(_In_ SessionMap* self, 
+    _In_z_ const char* sessionId);
+
+/*
+    Removes a session id from the SessionMap.
+
+    Returns: 
+        0 if the session id was removed or not found.
+        -1 if the SessionMap is NULL or invalid.
+
+    If the session id was not found, the SessionMap is unchanged.
+*/
+int SessionMap_Remove(_In_ SessionMap* self, 
+    _In_z_ const char* sessionId);
+
+#endif /* _omi_sessionmap_h */


### PR DESCRIPTION
Fix https://github.com/Microsoft/omi/issues/523
This change places management of the session cookie in the HttpClient layer.  There are four basic parts:

* TransactionProtocolHandler: Generates a session id for the current MI_Session and passes it to the HttpClient layer via MI_DestinationOptions.
* SessionMap - a HashMap providing a mapping between a session id and an HTTP cookie.
* HttpClient.c - adds/updates the SessionMap when a response is recieved with a MS-WSMAN cookie using the id created by TransactionProtocolHandler.  Ensures subsequent requests also include the session cookie.
NOTE: With office365, the session cookie changes virtually on every response and a single cookie cannot be used.
* TransactionProtocolHandler removes the session id from the SessionMap when the session is destroyed. This is done via a call to a new  export HttpClient_RemoveSession.

NOTE: The current implementation initializes the HashMap on first use since there is no clear global initialization point.  Since there is also no clear global cleanup, the internal HashMap array is also leaked on shutdown.  Allocations for hashMap entries should not be leaked since MI_Session clean removes the associated entry.

Unlike the previous attempt, this approach is able to track the session cookie for all types of responses and solves the case where an error, such as an timeout, can cause the cookie to stale for the next request.