### PR TITLE
Fixes preexec issue with multiple requests

### DIFF
--- a/Unix/base/messages.h
+++ b/Unix/base/messages.h
@@ -1850,8 +1850,8 @@ typedef struct _ExecPreexecReq
 }
 ExecPreexecReq;
 
-#define ExecPreexecReq_New() \
-    __ExecPreexecReq_New(0, 0, CALLSITE)
+#define ExecPreexecReq_New(operationId) \
+    __ExecPreexecReq_New(operationId, 0, CALLSITE)
 
 
 MI_INLINE ExecPreexecReq* __ExecPreexecReq_New(
@@ -1894,8 +1894,8 @@ typedef struct _ExecPreexecResp
 }
 ExecPreexecResp;
 
-#define ExecPreexecResp_New() \
-    __ExecPreexecResp_New(0, 0, CALLSITE)
+#define ExecPreexecResp_New(operationId) \
+    __ExecPreexecResp_New(operationId, 0, CALLSITE)
 
 
 MI_INLINE ExecPreexecResp* __ExecPreexecResp_New(

--- a/Unix/disp/agentmgr.c
+++ b/Unix/disp/agentmgr.c
@@ -1573,7 +1573,7 @@ static MI_Result _AgentMgr_ProcessPreExec(
 
     Strand_Init(STRAND_DEBUG(AgentPreExecRequest) &preexecContext->requestStrand, &AgentPreExec_RequestStrand_FT, 0, params);
 
-    if (!SendExecutePreexecRequest(preexecContext, _AgentMgr_PreExecFinished, uid, gid, proventry->nameSpace, proventry->className))
+    if (!SendExecutePreexecRequest(preexecContext, _AgentMgr_PreExecFinished, uid, gid, proventry->nameSpace, proventry->className, _NextOperationId()))
     {
         return MI_RESULT_FAILED;
     }

--- a/Unix/protocol/protocol.c
+++ b/Unix/protocol/protocol.c
@@ -1495,7 +1495,8 @@ MI_Boolean SendExecutePreexecRequest(
     uid_t  uid,
     gid_t  gid,
     const ZChar *nameSpace,
-    const ZChar *className
+    const ZChar *className,
+    MI_Uint64 operationId
     )
 {
     ExecPreexecReq *req = NULL;
@@ -1509,7 +1510,7 @@ MI_Boolean SendExecutePreexecRequest(
     preexecCtx->context = contextp;
     preexecCtx->completion = completion;
 
-    req = ExecPreexecReq_New();
+    req = ExecPreexecReq_New(operationId);
     if (!req)
     {
         PAL_Free(preexecCtx);
@@ -1561,14 +1562,15 @@ MI_Boolean SendExecutePreexecRequest(
 /* Creates and sends ExecPreexecResp request message */
 MI_Boolean SendExecutePreexecResponse(
     void *contextp, 
-    int retval
+    int retval,
+    MI_Uint64 operationId
     )
 {
     ExecPreexecResp *req = NULL;
     MI_Boolean retVal = MI_TRUE;
     ProtocolSocket *protocolSocket = s_permanentSocket;
 
-    req = ExecPreexecResp_New();
+    req = ExecPreexecResp_New(operationId);
     if (!req)
     {
         return MI_FALSE;

--- a/Unix/protocol/protocol.h
+++ b/Unix/protocol/protocol.h
@@ -204,11 +204,13 @@ MI_Boolean SendExecutePreexecRequest(
     uid_t  uid,
     gid_t  gid,
     const ZChar *nameSpace,
-    const ZChar *className);
+    const ZChar *className,
+    MI_Uint64 operationId);
 
 MI_Boolean SendExecutePreexecResponse(
     void *contextp, 
-    int retval);
+    int retval,
+    MI_Uint64 operationId);
 
 MI_Result Protocol_New_Agent_Request(
     ProtocolSocketAndBase** selfOut,

--- a/Unix/server/servercommon.c
+++ b/Unix/server/servercommon.c
@@ -1029,7 +1029,7 @@ static MI_Boolean _ProcessExecPreexecReq(
         trace_PreExecFailed(preexec);
     }
 
-    ret = SendExecutePreexecResponse(contextp, r);
+    ret = SendExecutePreexecResponse(contextp, r, msg->operationId);
 
     return ret;
 }


### PR DESCRIPTION
The class _ConnectionIn uses operationId as key to check for duplicate entries in hash table.  This causes multiple preexec requests to be ignored.
