### PR TITLE
Add logrotate for omi

### DIFF
--- a/Unix/installbuilder/GNUmakefile
+++ b/Unix/installbuilder/GNUmakefile
@@ -20,6 +20,11 @@ PACKAGE_DIR_SUFFIX = $(shell echo $(OUTPUTDIRNAME) | sed 's/output//' | sed 's~^
 PACKAGE_SSL_DECORATION = $(shell echo $(OUTPUTDIRNAME) | sed 's/output_openssl_0.9.8/ssl_098/' | sed 's/output_openssl_1.0.0/ssl_100/' | sed 's/output_openssl_1.1.0/ssl_110/')
 PACKAGE_DIR = $(TOP)/../Packages/$(BUILD_CONFIGURATION)$(PACKAGE_DIR_SUFFIX)
 
+# Selinux policy directories.
+SEPOLICY_SRC_DIR=$(TOP)/installbuilder/selinux
+SEPOLICY_DIR=$(OUTPUTDIR)/intermediate/tmp/selinux
+SEPOLICY_DIR_EL6=$(OUTPUTDIR)/intermediate/tmp/selinux.el6
+
 DISTRO_TYPE = $(PF)
 ifeq ($(PF),Linux)
 DISTRO_TYPE = $(PF)_$(PF_DISTRO)
@@ -27,11 +32,13 @@ endif
 
 DATAFILES = Base_OMI.data
 COMPRESS_KIT = 0
+BUILD_SEMODULE = 0
 
 ifeq ($(PF),Linux)
 DATAFILES += Linux.data
 endif
 ifeq ($(PF_DISTRO),ULINUX)
+BUILD_SEMODULE = 1
 DATAFILES += ULinux.data
 endif
 
@@ -71,6 +78,7 @@ ifeq ($(PF),Linux)
     OUTPUTFILE_LINE = --OUTPUTFILE=omi-$(CONFIG_VERSION)-$(CONFIG_PATCH_LEVEL).$(PACKAGE_SSL_DECORATION).ulinux.$(PF_ARCH)
     OUTPUTFILE_LINE_WITHSYMBOLS = $(OUTPUTFILE_LINE).$(WITH_SYMBOLS)
   else
+    BUILD_SEMODULE = 1
     OUTPUTFILE_LINE = --OUTPUTFILE=omi-$(CONFIG_VERSION)-$(CONFIG_PATCH_LEVEL).rhel.$(PF_MAJOR).$(PF_ARCH)
     OUTPUTFILE_LINE_WITHSYMBOLS = $(OUTPUTFILE_LINE).$(WITH_SYMBOLS)
   endif
@@ -123,7 +131,7 @@ else
 DPKG_LOCATION=
 endif
 
-all:
+all: sepolicy
 ifneq ($(PF),Darwin)
   ifneq ($(PF),Linux)
 	@echo "========================= Make OMI installer $(PF_DISTRO) with symbols"
@@ -302,6 +310,41 @@ else #($(PF),Darwin)
   endif #ifeq ($(PF),Linux)
 endif #($(PF),Darwin) 
 
+sepolicy: $(SEPOLICY_DIR_EL6)/omi-logrotate.pp $(SEPOLICY_DIR)/omi-logrotate.pp
+
 clean:
 #	sudo rm -rf $(OUTPUTDIR)/intermediate
 #	sudo rm -rf $(OUTPUTDIR)/release
+
+#--------------------------------------------------------------------------------
+# Build SELinux policy modules for omi-logrotate
+
+	# remove old policy module folders and files
+	rm -rf $(SEPOLICY_DIR_EL6)
+	rm -rf $(SEPOLICY_DIR)
+
+ifeq ($(BUILD_SEMODULE),1)
+$(SEPOLICY_DIR_EL6)/omi-logrotate.pp : $(SEPOLICY_SRC_DIR)/omi-logrotate.el6.te $(SEPOLICY_SRC_DIR)/omi-logrotate.fc
+	@echo "========================= Building EL6 selinux policy module for omi-logrotate"
+	mkdir -p $(SEPOLICY_DIR_EL6)
+	cp $(SEPOLICY_SRC_DIR)/omi-logrotate.el6.te $(SEPOLICY_DIR_EL6)/omi-logrotate.te
+	cp $(SEPOLICY_SRC_DIR)/omi-logrotate.fc $(SEPOLICY_DIR_EL6)/omi-logrotate.fc
+	cd $(SEPOLICY_DIR_EL6); make -f /usr/share/selinux/devel/Makefile
+
+$(SEPOLICY_DIR)/omi-logrotate.pp : $(SEPOLICY_SRC_DIR)/omi-logrotate.te $(SEPOLICY_SRC_DIR)/omi-logrotate.fc
+	@echo "========================= Building selinux policy module for omi-logrotate"
+	mkdir -p $(SEPOLICY_DIR)
+	cp $(SEPOLICY_SRC_DIR)/omi-logrotate.te $(SEPOLICY_DIR)
+	cp $(SEPOLICY_SRC_DIR)/omi-logrotate.fc $(SEPOLICY_DIR)/omi-logrotate.fc
+	cd $(SEPOLICY_DIR); make -f /usr/share/selinux/devel/Makefile
+else
+$(SEPOLICY_DIR_EL6)/omi-logrotate.pp : $(SEPOLICY_SRC_DIR)/omi-logrotate.el6.te $(SEPOLICY_SRC_DIR)/omi-logrotate.fc
+	@echo "========================= Building EL6 selinux policy module"
+	mkdir -p $(SEPOLICY_DIR_EL6)
+	touch $(SEPOLICY_DIR_EL6)/omi-logrotate.pp
+
+$(SEPOLICY_DIR)/omi-logrotate.pp : $(SEPOLICY_SRC_DIR)/omi-logrotate.te $(SEPOLICY_SRC_DIR)/omi-logrotate.fc
+	@echo "========================= Building selinux policy module"
+	mkdir -p $(SEPOLICY_DIR)
+	touch $(SEPOLICY_DIR)/omi-logrotate.pp
+endif

--- a/Unix/installbuilder/conf/omilogrotate.conf
+++ b/Unix/installbuilder/conf/omilogrotate.conf
@@ -1,0 +1,41 @@
+# omi logs rotate configuration settings
+/var/opt/omi/log/omiserver.log {
+    # keep 5 worth of backlogs
+    rotate 5
+
+    # If the log file is missing, go on to the next one
+    # without issuing an error message.
+    missingok
+
+    # Do not rotate the log if it is empty,
+    # this overrides the ifempty option.
+    notifempty
+
+    # Old versions of log files are compressed with gzip by default.
+    compress
+
+    # Log files are rotated only if they grow bigger then 100M.
+    size 100M
+
+    # Truncate the original log file in place after creating a copy,
+    # instead of moving the old log file and optionally creating a new one.
+    copytruncate
+}
+
+/var/opt/omi/log/omiagent.root.root.log {
+    rotate 5
+    missingok
+    notifempty
+    compress
+    size 100M
+    copytruncate
+}
+
+/var/opt/omi/log/miclient.log {
+    rotate 5
+    missingok
+    notifempty
+    compress
+    size 100M
+    copytruncate
+}

--- a/Unix/installbuilder/datafiles/Linux.data
+++ b/Unix/installbuilder/datafiles/Linux.data
@@ -9,6 +9,7 @@ pam_file_passwd_ubuntu: 'omi auth required pam_env.so\nomi auth required pam_uni
 
 PF:           'Linux'
 SERVICE_CTL:  '/opt/omi/bin/service_control'
+SEPKG_DIR_OMI: '/usr/share/selinux/packages/omi-logrotate'
 
 %Files
 /opt/omi/bin/support/installssllinks;         ../scripts/installssllinks;                              755; root; ${{ROOT_GROUP_NAME}}
@@ -20,12 +21,23 @@ SERVICE_CTL:  '/opt/omi/bin/service_control'
 /opt/omi/bin/support/config_keytab_update.sh; ../scripts/config_keytab_update.sh;                      755; root; ${{ROOT_GROUP_NAME}}
 /opt/omi/bin/support/allocdump;               ../tools/allocdump;                                      755; root; ${{ROOT_GROUP_NAME}}
 /opt/omi/bin/support/gdb_allocdump;           ../tools/gdb_allocdump;                                  644; root; ${{ROOT_GROUP_NAME}}
-/etc//opt/omi/conf/omilogrotate.conf;                 ../installbuilder/conf/omilogrotate.conf; 755; root; ${{ROOT_GROUP_NAME}}
+/etc/opt/omi/conf/omilogrotate.conf;          ../installbuilder/conf/omilogrotate.conf;                644; root; ${{ROOT_GROUP_NAME}}; conffile
+${{SEPKG_DIR_OMI}}/omi-logrotate.fc;          ../installbuilder/selinux/omi-logrotate.fc;              644; root; ${{ROOT_GROUP_NAME}};
+${{SEPKG_DIR_OMI}}/omi-logrotate.te;          ../installbuilder/selinux/omi-logrotate.te;              644; root; ${{ROOT_GROUP_NAME}};
+${{SEPKG_DIR_OMI}}/omi-logrotate.el6.te;      ../installbuilder/selinux/omi-logrotate.el6.te;          644; root; ${{ROOT_GROUP_NAME}};
+${{SEPKG_DIR_OMI}}/omi-logrotate.pp;          intermediate/tmp/selinux/omi-logrotate.pp;               755; root; ${{ROOT_GROUP_NAME}};
+${{SEPKG_DIR_OMI}}/omi-logrotate.el6.pp;      intermediate/tmp/selinux.el6/omi-logrotate.pp;           755; root; ${{ROOT_GROUP_NAME}};
+
+%Links
+/etc/logrotate.d/omi;                         /etc/opt/omi/conf/omilogrotate.conf;                     644; root; ${{ROOT_GROUP_NAME}}
 
 %Directories
-/opt/omi/lib;                            775; root; omiusers
-/etc/opt/omi/conf/omiregister;           775; root; omiusers
-/var/opt/omi/omiusers;                   775; root; omiusers
+/opt/omi/lib;                                775; root; omiusers
+/etc/opt/omi/conf/omiregister;               775; root; omiusers
+/var/opt/omi/omiusers;                       775; root; omiusers
+/usr/share/selinux/packages;                 755; root; ${{ROOT_GROUP_NAME}}; sysdir
+/usr/share/selinux/packages/omi-logrotate;   755; root; ${{ROOT_GROUP_NAME}}; sysdir
+/etc/logrotate.d;                                                                                                                         755; root; ${{ROOT_GROUP_NAME}}; sysdir
 
 %Defines
 ULINUX
@@ -190,15 +202,6 @@ ConfigureOmiService() {
     ${{SERVICE_CTL}} start
 }
 
-ConfigureLogRotate()
-{
-    echo "Configure log rotate for OMI"
-    # create the logrotate file if it doesn't exist
-    if [ ! -f /etc/logrotate.d/omi ]; then
-        cat /etc/opt/omi/conf/omilogrotate.conf > /etc/logrotate.d/omi
-    fi
-}
-
 ConfigureCronForLogRotate()
 {
     echo "Checking if cron is installed..."
@@ -289,7 +292,6 @@ chmod 500 /opt/omi/bin/support/config_keytab_update.sh
 /opt/omi/bin/support/config_keytab_update.sh --configure
 
 ConfigureOmiService
-ConfigureLogRotate
 ConfigureCronForLogRotate
 
 %Preuninstall_10
@@ -328,3 +330,32 @@ if ${{PERFORMING_UPGRADE_NOT}}; then
     fi
 fi
 
+%Postinstall_1500
+if [ -e /usr/sbin/semodule ]; then
+    echo "System appears to have SELinux installed, attempting to install selinux policy module for logrotate"
+    echo "  Trying ${{SEPKG_DIR_OMI}}/omi-logrotate.pp ..."
+    sestatus=`sestatus|grep status|awk '{print $3}'`
+    if [ -e /usr/bin/dpkg-deb -a "$sestatus" = "disabled" ]; then
+        echo "INFO: omi-logrotate selinux policy module has not yet installed due to selinux is disabled."
+        echo "When enabling selinux, load omi-logrotate module manually with following commands for logrotate feature to work properly for omi logs."
+        echo "/usr/sbin/semodule -i $SEPKG_DIR_OMI/omi-logrotate.pp >/dev/null 2>&1"
+        echo "/sbin/restorecon -R /var/opt/omi/log/ > /dev/null 2>&1"
+    else
+        /usr/sbin/semodule -i ${{SEPKG_DIR_OMI}}/omi-logrotate.pp >/dev/null 2>&1
+        if [ $? -ne 0 ]; then
+            echo "ERROR: omi-logrotate selinux policy module versions could not be installed"
+            exit 0
+        fi
+
+        echo "  Labeling omi log files ..."
+        /sbin/restorecon -R /var/opt/omi/log/ > /dev/null 2>&1
+    fi
+fi
+
+%Postuninstall_1500
+if [ -e /usr/sbin/semodule ]; then
+    if [ ! -z "$(/usr/sbin/semodule -l | grep omi-logrotate)" ]; then
+        echo "Removing selinux policy module for omi-logrotate ..."
+        /usr/sbin/semodule -r omi-logrotate
+    fi
+fi

--- a/Unix/installbuilder/datafiles/Linux.data
+++ b/Unix/installbuilder/datafiles/Linux.data
@@ -20,6 +20,7 @@ SERVICE_CTL:  '/opt/omi/bin/service_control'
 /opt/omi/bin/support/config_keytab_update.sh; ../scripts/config_keytab_update.sh;                      755; root; ${{ROOT_GROUP_NAME}}
 /opt/omi/bin/support/allocdump;               ../tools/allocdump;                                      755; root; ${{ROOT_GROUP_NAME}}
 /opt/omi/bin/support/gdb_allocdump;           ../tools/gdb_allocdump;                                  644; root; ${{ROOT_GROUP_NAME}}
+/etc//opt/omi/conf/omilogrotate.conf;                 ../installbuilder/conf/omilogrotate.conf; 755; root; ${{ROOT_GROUP_NAME}}
 
 %Directories
 /opt/omi/lib;                            775; root; omiusers
@@ -189,6 +190,43 @@ ConfigureOmiService() {
     ${{SERVICE_CTL}} start
 }
 
+ConfigureLogRotate()
+{
+    echo "Configure log rotate for OMI"
+    # create the logrotate file if it doesn't exist
+    if [ ! -f /etc/logrotate.d/omi ]; then
+        cat /etc/opt/omi/conf/omilogrotate.conf > /etc/logrotate.d/omi
+    fi
+}
+
+ConfigureCronForLogRotate()
+{
+    echo "Checking if cron is installed..."
+    # warn user that he need to install cron if cron doesn't install
+    which cron >/dev/null 2>&1
+    if [ $? -ne 0 ]; then
+        which crond >/dev/null 2>&1
+        if [ $? -ne 0 ]; then
+            echo "WARNING: LogRotate can't be enabled, please install cron at first!"
+            return
+        fi
+    fi
+
+    echo "Checking if cron/crond service is started..."
+    # warn user that he need to start cron/crond service if cron doesn't start
+    cronid=$(pidof cron > /dev/null 2>&1)
+    crondid=$(pidof crond > /dev/null 2>&1)
+    if [ ! -z "$cronid" -a ! -z "$crondid" ]; then
+        echo "WARNING: LogRotate can be enabled, but please start cron/crond service!"
+    fi
+
+    echo "Set up a cron job to OMI logrotate every 15 minutes"
+    # create the cron file if it doesn't exist
+    if [ ! -f /etc/cron.d/omilogrotate ]; then
+        (echo "*/15 * * * * root /usr/sbin/logrotate /etc/logrotate.d/omi >/dev/null 2>&1" > /etc/cron.d/omilogrotate) > /dev/null 2>&1
+    fi
+}
+
 %Preinstall_10
 #include OmiService_funcs
 
@@ -251,6 +289,8 @@ chmod 500 /opt/omi/bin/support/config_keytab_update.sh
 /opt/omi/bin/support/config_keytab_update.sh --configure
 
 ConfigureOmiService
+ConfigureLogRotate
+ConfigureCronForLogRotate
 
 %Preuninstall_10
 #include OmiService_funcs
@@ -266,6 +306,10 @@ if ${{PERFORMING_UPGRADE_NOT}}; then
     rm -f /opt/omi/lib/libcrypto* /opt/omi/lib/libssl* /opt/omi/lib/.libcrypto* /opt/omi/lib/.libssl*
     rmdir /opt/omi/lib > /dev/null 2>&1
     rmdir /opt/omi > /dev/null 2>&1
+
+    # Clean up cron and logrotate
+    rm -f /etc/cron.d/omilogrotate > /dev/null 2>&1
+    rm -f /etc/logrotate.d/omi > /dev/null 2>&1
 
     egrep -q "^omiusers:" /etc/group
     if [ $? -eq 0 ]; then

--- a/Unix/installbuilder/selinux/omi-logrotate.el6.te
+++ b/Unix/installbuilder/selinux/omi-logrotate.el6.te
@@ -1,0 +1,13 @@
+module omi-logrotate 1.0;
+
+require {  
+        type var_log_t;  
+        type logrotate_t;  
+        class file getattr;  
+        class dir write;  
+}  
+
+#============= logrotate_t ==============  
+ 
+allow logrotate_t var_log_t:dir write;  
+allow logrotate_t var_log_t:file getattr;  

--- a/Unix/installbuilder/selinux/omi-logrotate.fc
+++ b/Unix/installbuilder/selinux/omi-logrotate.fc
@@ -1,0 +1,1 @@
+/var/opt/omi/log(/.*)?         system_u:object_r:var_log_t:s0

--- a/Unix/installbuilder/selinux/omi-logrotate.te
+++ b/Unix/installbuilder/selinux/omi-logrotate.te
@@ -1,0 +1,13 @@
+module omi-logrotate 1.0;
+
+require {  
+        type var_log_t;  
+        type logrotate_t;  
+        class file getattr;  
+        class dir write;  
+}  
+
+#============= logrotate_t ==============  
+ 
+allow logrotate_t var_log_t:dir write;  
+allow logrotate_t var_log_t:file getattr;  


### PR DESCRIPTION
@palladia , I only tested on Ubuntu16.04x64, just new this PR, could you help to review it?
I will test on other Linux when no other more high priority tasks, also I only log rotate `/var/opt/omi/log/omiserver.log` now, do we need to rotate `/var/opt/omi/log/omiagent.root.root.log`, I am not sure if it exist on all Linux now but will check it later if we need omiagent log too.