### PR TITLE
Fixes leak temp files

### DIFF
--- a/Unix/scripts/config_keytab_update.sh
+++ b/Unix/scripts/config_keytab_update.sh
@@ -19,6 +19,11 @@ checkConfiguration()
     return 0
 }
 
+cleanTempFile()
+{
+    # clean temp file
+    rm -f $tmpfile > /dev/null 2>&1
+}
 
 configure()
 {
@@ -58,6 +63,9 @@ unconfigure()
     grep -v "$omikeytab" $tmpfile >$tmpfile2 
     crontab $tmpfile2
 
+    # clean temp file
+    rm -f $tmpfile2 > /dev/null 2>&1
+
     timestamp=$(date +%F\ %T)
     printf "$timestamp : Crontab no longer configured to update omi keytab.\n"
 }
@@ -84,3 +92,4 @@ do
     esac
 done
 
+cleanTempFile

--- a/Unix/tools/ktstrip
+++ b/Unix/tools/ktstrip
@@ -49,6 +49,15 @@ delete_list=$(mktemp)
 cmd=$(mktemp)
 tmp_kt="/tmp/tmp.kt"
 
+# clean temp files
+CleanTempFiles()
+{
+    echo "Cleaning temp files..." 2>&1
+    rm -f $list > /dev/null 2>&1
+    rm -f $delete_list > /dev/null 2>&1
+    rm -f $cmd > /dev/null 2>&1
+}
+
 #
 # Use ktutil to strip the soure keytab of anything but host/ and RestrictedKrbHost/ principals
 # First, get a list of principals and put it in a temp file to retain its line structure. 
@@ -57,11 +66,13 @@ tmp_kt="/tmp/tmp.kt"
 which ktutil 2>&1 >/dev/null
 if [ $? -ne 0 ]; then
    echo "ktutil does not exist" 2>&1
+   CleanTempFiles
    exit 3
 fi    
-printf "read_kt $SRC_KT\nlist\n" | ktutil >$list 2>&1 >/dev/null
+printf "read_kt $SRC_KT\nlist\n" | ktutil >$list 2>&1
 if [ $? -ne 0 ]; then
    echo "we only support MIT Kerberos on Linux at present" 2>&1
+   CleanTempFiles
    exit 3
 fi
 
@@ -80,6 +91,15 @@ printf "write_kt $tmp_kt\n"   >>$cmd
 # The command file will now ready to delete all unneeded entries.
 printf "Creating $DST_KT\n"
 cat $cmd | ktutil
+
+CleanTempFiles
+
+if [ ! -f $tmp_kt ]
+then
+    echo "File " $tmp_kt " is not generated, so we skip configure Kerberos authentication for omi." 2>&1
+    exit 0
+fi
+
 printf "Move $tmp_kt to $DST_KT\n"
 mv $tmp_kt $DST_KT
 


### PR DESCRIPTION
Fixed #570 , @Microsoft/omi-devs , could you help to review it? thank you!
Fixed result:
```
root@ost64-ct7-06.scx.com  # /opt/omi/bin/support/ktstrip /tmp/newtmp.kt /etc/opt/omi/creds/omi.keytab
src kt = /tmp/newtmp.kt
Creating /etc/opt/omi/creds/omi.keytab
ktutil:  read_kt /tmp/newtmp.kt 
ktutil:  delete_entry 1
ktutil:  write_kt /tmp/tmp.kt
ktutil:  Cleaning temp files...
File  /tmp/tmp.kt  is not generated, so we skip configure Kerberos authentication for omi.

~
root@ost64-ct7-06.scx.com  # echo $?
0 
```