### PR TITLE
Decrypt authorized message sent over HTTPS

### DIFF
--- a/Unix/http/httpauth.c
+++ b/Unix/http/httpauth.c
@@ -2259,29 +2259,26 @@ MI_Result Process_Authorized_Message(
 {
     HttpRequestMsg* msg;
 
-    if (!handler->ssl)
-    {
 #if ENCRYPT_DECRYPT
-        if (!Http_DecryptData(handler, &handler->recvHeaders, &handler->recvPage) )
-        {
-            // Failed decrypt. No encryption counts as success. So this is an error in the decrpytion, probably 
-            // bad credential
+    if (!Http_DecryptData(handler, &handler->recvHeaders, &handler->recvPage) )
+    {
+        // Failed decrypt. No encryption counts as success. So this is an error in the decrpytion, probably
+        // bad credential
 
-            return MI_RESULT_FAILED;
-        }
-        else 
-        {
-            if (FORCE_TRACING || handler->enableTracing)
-            {
-                char after_decrypt[] = "\n------------ After Decryption ---------------\n";
-                char after_decrypt_end[] = "\n-------------- End Decrypt ------------------\n";
-                _WriteTraceFile(ID_HTTPRECVTRACEFILE, &after_decrypt, sizeof(after_decrypt));
-                _WriteTraceFile(ID_HTTPRECVTRACEFILE, (char *)(handler->recvPage+1), handler->recvPage->u.s.size);
-                _WriteTraceFile(ID_HTTPRECVTRACEFILE, &after_decrypt_end, sizeof(after_decrypt_end));
-            }
-        }
-#endif
+        return MI_RESULT_FAILED;
     }
+    else
+    {
+        if (FORCE_TRACING || handler->enableTracing)
+        {
+            char after_decrypt[] = "\n------------ After Decryption ---------------\n";
+            char after_decrypt_end[] = "\n-------------- End Decrypt ------------------\n";
+            _WriteTraceFile(ID_HTTPRECVTRACEFILE, &after_decrypt, sizeof(after_decrypt));
+            _WriteTraceFile(ID_HTTPRECVTRACEFILE, (char *)(handler->recvPage+1), handler->recvPage->u.s.size);
+            _WriteTraceFile(ID_HTTPRECVTRACEFILE, &after_decrypt_end, sizeof(after_decrypt_end));
+        }
+    }
+#endif
 
     AuthInfo_Copy(&handler->recvHeaders.authInfo, &handler->authInfo);
     msg = HttpRequestMsg_New(handler->recvPage, &handler->recvHeaders);


### PR DESCRIPTION
 - Previously a check was performed to see if the current message was
   sent over SSL. In cases where the message was sent as
   Content-Type: multipart/encrypted, the message would be improperly parsed
   resulting in a 401 unauthorized being sent to the client.

   By all accounts, the PSRP implementation on Windows in PowerShell 5 and
   PowerShell 6 allows a multipart/encrypted message to be sent in response
   to the challenge message.

   Since the Http_DecryptData function already ignores / returns immediately
   for messages that are not multipart/encrypted, this change should
   simply make the protocol handling more tolerant.

 - This fixes an issue when trying to establish a connection to an OMI server
   from the WinRM Ruby library where NTLM/SPNEGO is enabled in the OMI server.