### PR TITLE
Allow writing SPNEGO responses over HTTPS

### DIFF
--- a/Unix/http/httpclient.c
+++ b/Unix/http/httpclient.c
@@ -900,7 +900,7 @@ static Http_CallbackResult _ReadData(
     }
 
 
-    if (!handler->ssl && handler->encrypting)
+    if (handler->encrypting)
     {
 
 #if ENCRYPT_DECRYPT


### PR DESCRIPTION
 - Previously a check was performed when writing headers to see if the current
   handler is operating over SSL. In cases where the message was sent as
   Content-Type: multipart/encrypted, the message response would be returned
   as application/soap+xml if the transport was HTTPS. This could confuse
   clients (such as the winrm gem) as they are expecting a response of
   multipart/encrypted.

   By all accounts, the PSRP implementation on Windows in PowerShell 5 and
   PowerShell 6 allows multipart/encrypted spnego messages to be sent over
   HTTPS.

   Since the code already checks for handler->encryptedTransaction prior to
   determining how to write response headers, it is safe to remove the SSL
   check to allow mulitpart/encrypted over HTTPS. This change should
   simply make the protocol handling more tolerant.

 - This fixes an issue when trying to establish a connection to an OMI server
   from the WinRM Ruby library where NTLM/SPNEGO is enabled in the OMI server.

 - Similarly change the behavior in httpclient.c to match what has been changed
   on the server response writing in this commit, and the server request
   reading in the prior commit ebe43ea5aa48300f222946cb8eaefa7478b204f4