### PR TITLE
add WSMAN_BUF_CAPACITY SDL unittest

### DIFF
--- a/Unix/tests/wsman/test_wsbuf.cpp
+++ b/Unix/tests/wsman/test_wsbuf.cpp
@@ -1773,5 +1773,25 @@ cleanup:
 }
 NitsEndTest
 
+NitsTestWithSetup(TestBigString, TestWsbufSetup)
+{
+    String result;
+
+    if(!TEST_ASSERT (MI_RESULT_OK == WSBuf_Init(&s_buf, 10)))
+        NitsReturn;
+
+    {
+        result += TEST_STR_ENCODED;
+        std::string str = string(10000 * 1024, '.');
+        char *cstr = new char[str.length() + 1];
+        strcpy(cstr, str.c_str());
+        TEST_ASSERT (MI_RESULT_FAILED == WSBuf_AddString(&s_buf, cstr) );
+        delete [] cstr;
+    }
+
+    TEST_ASSERT (MI_RESULT_OK == WSBuf_Destroy(&s_buf));
+}
+NitsEndTest
+
 #endif
 


### PR DESCRIPTION
I just add 1 SDL unittest here at first. Don't know how to verify omitest.log in unittest now, will add it once know it.
Test:
```
NitsTestWithSetup(TestBigString, TestWsbufSetup)
{
    String result;

    if(!TEST_ASSERT (MI_RESULT_OK == WSBuf_Init(&s_buf, 10)))
        NitsReturn;

    {
        result += TEST_STR_ENCODED;
        std::string str = string(10000 * 1024, '.');
        char *cstr = new char[str.length() + 1];
        strcpy(cstr, str.c_str());
        TEST_ASSERT (MI_RESULT_FAILED == WSBuf_AddString(&s_buf, cstr) );
        delete [] cstr;
    }

    TEST_ASSERT (MI_RESULT_OK == WSBuf_Destroy(&s_buf));
}
NitsEndTest
```
Get in /home/jumping/bld-omi/omi/Unix/output/var/log/omitest.log:
2019/01/10 04:54:40 [18801,18801] ERROR: wsbuf.c(531): EventId=20151 Priority=ERROR Wsman malloc exceeds reasonable limit: 10241032
