### PR TITLE
Add logrotate state file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: c
+dist: trusty
 
 matrix:
   include:

--- a/Unix/installbuilder/datafiles/Linux.data
+++ b/Unix/installbuilder/datafiles/Linux.data
@@ -227,7 +227,7 @@ ConfigureCronForLogRotate()
     echo "Set up a cron job to OMI logrotate every 15 minutes"
     # create the cron file if it doesn't exist
     if [ ! -f /etc/cron.d/omilogrotate ]; then
-        (echo "*/15 * * * * root /usr/sbin/logrotate /etc/logrotate.d/omi >/dev/null 2>&1" > /etc/cron.d/omilogrotate) > /dev/null 2>&1
+        (echo "*/15 * * * * root /usr/sbin/logrotate /etc/logrotate.d/omi --state /var/opt/omi/log/omi-logrotate.status >/dev/null 2>&1" > /etc/cron.d/omilogrotate) > /dev/null 2>&1
     fi
 }
 


### PR DESCRIPTION
Fixes #626 , @Microsoft/omi-devs , could you help to review this PR? thanks.

We have verified on 4 platforms:

Client | Selinux status
-- | --
ost64-ct6-01 | enabled
ost64-rh5-01 | disabled
ost64-ub16-02 | enabled
ost64-ub14-02 | disabled



After fixes, the new log status file shows as below:
```
root@ost64-rh5-01  # cat /var/lib/omi-logrotate.status
logrotate state -- version 2
"/var/opt/omi/log/omiserver.log" 2019-5-4
"/var/opt/omi/log/omiagent.root.root.log" 2019-5-4
"/var/opt/omi/log/miclient.log" 2019-5-4
```