### PR TITLE
Fixed #623: getaddrinfo calls with a service name fail on Docker images that lack /etc/services.

### DIFF
--- a/Unix/http/httpclientauth.c
+++ b/Unix/http/httpclientauth.c
@@ -2562,7 +2562,9 @@ static char *_BuildInitialGssAuthHeader(_In_ HttpClient_SR_SocketData * self, MI
         hints.ai_socktype = SOCK_STREAM;
         hints.ai_flags = AI_CANONNAME;
 
-        if ((gai_result = getaddrinfo(self->hostname, "http", &hints, &info)) != 0)
+        // Use a port number rather than a service name (http), which relies on /etc/services, which may not be available.
+        // The port number is irrelevant anyway since we're only using info->ai_canonname below.
+        if ((gai_result = getaddrinfo(self->hostname, "80", &hints, &info)) != 0)
         {
             trace_HTTP_GetAddrInfoError(gai_strerror(gai_result));
             return NULL;


### PR DESCRIPTION
The fix is simply to not use a service name.