### PR TITLE
Fixes /opt be removed when dpkg -P omi

### DIFF
--- a/Unix/installbuilder/datafiles/Linux.data
+++ b/Unix/installbuilder/datafiles/Linux.data
@@ -298,6 +298,11 @@ ConfigureCronForLogRotate
 %Preuninstall_10
 #include OmiService_funcs
 
+# dpkg -P omi will remove /opt, to fix the issue, we touch a file under /opt/omi
+if ${{PERFORMING_PURGE_REMOVE_FOR_DPKG}}; then
+    [ ! -f /opt/omi/.omi_not_delete ] && touch /opt/omi/.omi_not_delete
+fi
+
 # If we're called for upgrade, don't do anything
 if ${{PERFORMING_UPGRADE_NOT}}; then
     RemoveOmiService

--- a/Unix/installbuilder/datafiles/Linux_DPKG.data
+++ b/Unix/installbuilder/datafiles/Linux_DPKG.data
@@ -1,5 +1,6 @@
 %Variables
 PERFORMING_UPGRADE_NOT: '[ "$1" != "upgrade" -a "$1" != "purge" ]'
+PERFORMING_PURGE_REMOVE_FOR_DPKG: '[ "$1" = "purge" -o "$1" = "remove" ]'
 PACKAGE_TYPE: 'DPKG'
 
 %Dependencies

--- a/Unix/installbuilder/datafiles/Linux_RPM.data
+++ b/Unix/installbuilder/datafiles/Linux_RPM.data
@@ -1,5 +1,6 @@
 %Variables
 PERFORMING_UPGRADE_NOT: '[ "$1" -ne 1 ]'
+PERFORMING_PURGE_REMOVE_FOR_DPKG: '[ 0 != 0 ]'
 PACKAGE_TYPE: 'RPM'
 
 


### PR DESCRIPTION
@microsoft/omi-devs 
This PR fixes `dpkg -P omi` will remove `/opt` folder on debian/ubuntu systems, the root cause is `dpkg -P` by design will remove package installed folder if its sub-folders and sub-files are removed, more detail: 
**Same issue:** https://stackoverflow.com/questions/13021002/my-deb-file-removes-opt
**Related on debian discussion:**
https://lists.debian.org/debian-devel/2006/03/msg00224.html
https://lists.debian.org/debian-devel/2006/03/msg00214.html 

BTW, `dpkg -P omi` or `dpkg --purge omi` will not pass "$1" as "purge" as below, so I check `PERFORMING_PURGE_REMOVE_FOR_DPKG: '[ "$1" = "purge" -o "$1" = "remove" ]'` value in code.
```
~
root@ost64-deb8-02  # dpkg --purge omi
(Reading database ... 30127 files and directories currently installed.)
Removing omi (1.6.0.230) ...
```
    **test:remove**  # here I print "test:$1"
```
Unconfiguring omid service ...
2019-06-12 01:01:44 : Crontab no longer configured to update omi keytab.
Deleting omiusers group ...
Deleting omi service account ...
Purging configuration files for omi (1.6.0.230) ...
dpkg: warning: while removing omi, directory '/var/opt/omi/log' not empty so not removed
dpkg: warning: while removing omi, directory '/etc/opt/omi/ssl' not empty so not removed
dpkg: warning: while removing omi, directory '/etc/opt/omi/conf/sockets' not empty so not removed
```

After the fixes, output of `dpkg -P omi` shows as below:
```
~
root@ost64-deb8-02  # dpkg -P omi
(Reading database ... 30127 files and directories currently installed.)
Removing omi (1.6.0.230) ...
Unconfiguring omid service ...
2019-06-12 01:07:41 : Crontab no longer configured to update omi keytab.
Deleting omiusers group ...
Deleting omi service account ...
Purging configuration files for omi (1.6.0.230) ...
dpkg: warning: while removing omi, directory '/opt/omi' not empty so not removed
dpkg: warning: while removing omi, directory '/var/opt/omi/log' not empty so not removed
dpkg: warning: while removing omi, directory '/etc/opt/omi/ssl' not empty so not removed
dpkg: warning: while removing omi, directory '/etc/opt/omi/conf/sockets' not empty so not removed
```