### PR TITLE
Adding /opt/omi/bin to PATH to be able to set use non-default openssl

### DIFF
--- a/Unix/scripts/installssllinks
+++ b/Unix/scripts/installssllinks
@@ -1,4 +1,5 @@
 #!/bin/sh
+export PATH=/opt/omi/bin:$PATH
 
 ATTEMPT_HMAC_LINK_CREATION=0
 


### PR DESCRIPTION
I'm working on making the installation work of OMS / OMI / DSC / SCX with custom installation of OpenSSL 1.1 on an old distro (SLES11 SP4) which comes with default openssl 0.9.

Until know I solved all installation issue.

But at runtime OMI is running installssllinks which uses openssl to replace some links. So we would like that installssllinks uses the "openssl"  symlink to openssl 1.1 that will be provided in /opt/omi/bin 