### PR TITLE
Fixes suse11 openssl1 issue

### DIFF
--- a/Unix/installbuilder/datafiles/Base_OMI.data
+++ b/Unix/installbuilder/datafiles/Base_OMI.data
@@ -369,6 +369,24 @@ OPENSSL_PATH="openssl"
 #endif
 #endif
 
+is_suse11_platform_with_openssl1(){
+  if [ -e /etc/SuSE-release ];then
+     VERSION=`cat /etc/SuSE-release|grep "VERSION = 11"|awk 'FS=":"{print $3}'`
+     if [ ! -z "$VERSION" ];then
+        which openssl1>/dev/null 2>&1
+        if [ $? -eq 0 -a $VERSION -eq 11 ];then
+           return 0
+        fi
+     fi
+  fi
+  return 1
+}
+
+is_suse11_platform_with_openssl1
+if [ $? -eq 0 ];then
+   OPENSSL_PATH="openssl1"
+fi
+
 WriteSSLconfig() {
     # Generate ssl.cnf
     cat > $cnffile <<EOF


### PR DESCRIPTION
When openssl1 installed but openssl not install, it meet below error in exist version, and this PR fixes omi part of the issue.
```
sh scx-1.6.2-345.universal.x64.sh --install
Extracting...
Installing cross-platform agent ...
----- Queuing package: omi (omi-1.6.2-0.ulinux.x64) for installation -----
----- Queuing package: scx (scx-1.6.2-345.universal.x64) for installation -----
----- Installing packages:  100/omi-1.6.2-0.ulinux.x64.rpm 100/scx-1.6.2-345.universal.x64.rpm -----
Creating omiusers group ...
Creating omi group ...
Creating omi service account ...
/var/tmp/rpm-tmp.49888: line 21: openssl: command not found
Error generating ssl keys. Now trying fallback FQDN : localhost.local
/var/tmp/rpm-tmp.49888: line 21: openssl: command not found
Unexpected error : /etc/opt/omi/ssl/omikey.pem or /etc/opt/omi/ssl/omi.pem were not generated by openssl
Fully qualified domain name likely not RFC compliant
error: %post(omi-1.6.2-0.x86_64) scriptlet failed, exit status 1
/var/tmp/rpm-tmp.49888: line 3: openssl: command not found
Unsupported OpenSSL version - must be either 0.9.8* or 1.0.*.
Installation cannot proceed.
error: %pre(scx-1.6.2-345.x86_64) scriptlet failed, exit status 1
error:   install: %pre scriptlet failed (2), skipping scx-1.6.2-345
Checking if Apache is installed ...
Apache not found, will not install
Checking if MySQL is installed ...
MySQL not found, will not install

```