### PR TITLE
Add SUSEPPC openssl110 support

### DIFF
--- a/Unix/installbuilder/GNUmakefile
+++ b/Unix/installbuilder/GNUmakefile
@@ -77,7 +77,16 @@ ifeq ($(PF),Linux)
     OUTPUTFILE_LINE_WITHSYMBOLS = $(OUTPUTFILE_LINE).$(WITH_SYMBOLS)
   else
     ifeq ($(PF_DISTRO),SUSE)
-      OUTPUTFILE_LINE = --OUTPUTFILE=omi-$(CONFIG_VERSION)-$(CONFIG_PATCH_LEVEL).suse.$(PF_MAJOR).$(PF_ARCH)
+      sslversion = `openssl version`
+      SSL_VERSION_SUSEPPC_PREFIX=$(shell echo $(sslversion) | head -c 12| tail -c 4)
+      ifeq ($(SSL_VERSION_SUSEPPC_PREFIX),1.0.)
+        SSL_SHORT=ssl_100
+      else
+          ifeq ($(SSL_VERSION_SUSEPPC_PREFIX),1.1.)
+            SSL_SHORT=ssl_110
+          endif
+      endif
+      OUTPUTFILE_LINE = --OUTPUTFILE=omi-$(CONFIG_VERSION)-$(CONFIG_PATCH_LEVEL).$(SSL_SHORT).suse.$(PF_MAJOR).$(PF_ARCH)
       OUTPUTFILE_LINE_WITHSYMBOLS = $(OUTPUTFILE_LINE).$(WITH_SYMBOLS)
     else
       OUTPUTFILE_LINE = --OUTPUTFILE=omi-$(CONFIG_VERSION)-$(CONFIG_PATCH_LEVEL).rhel.$(PF_MAJOR).$(PF_ARCH)


### PR DESCRIPTION
@microsoft/omi-devs , adds suse ppc with openssl 1.1.* support, the built binary will like `omi-1.6.2-123.ssl_110.suse.12.ppc`, need review, thanks.