### PR TITLE
Change "-e" to "-f" to fix Solaris install failure

### DIFF
--- a/Unix/installbuilder/datafiles/Base_OMI.data
+++ b/Unix/installbuilder/datafiles/Base_OMI.data
@@ -370,7 +370,7 @@ OPENSSL_PATH="openssl"
 #endif
 
 is_suse11_platform_with_openssl1(){
-  if [ -e /etc/SuSE-release ];then
+  if [ -f /etc/SuSE-release ];then
      VERSION=`cat /etc/SuSE-release|grep "VERSION = 11"|awk 'FS=":"{print $3}'`
      if [ ! -z "$VERSION" ];then
         which openssl1>/dev/null 2>&1


### PR DESCRIPTION
On Solaris, omi install fail as below message, after change "-e" to "-f", the issue has gone.
```
## Installing part 1 of 1.
[ verifying class <none> ]
[ verifying class <config> ]
## Executing postinstall script.
/var/sadm/pkg/MSFTomi/install/postinstall: test: argument expected
pkgadd: ERROR: postinstall script did not complete successfully
Installation of <MSFTomi> failed.

```