### PR TITLE
Fix service_control timing issue

### DIFF
--- a/Unix/installbuilder/service_scripts/service_control.linux
+++ b/Unix/installbuilder/service_scripts/service_control.linux
@@ -69,7 +69,7 @@ wait_until_omi_stops()
 
     COUNTER=$(( $1 * 2 )) # Since we sleep 0.5 seconds, compute number of seconds
     while [ $COUNTER -gt 0 ]; do
-        is_omi_running && return $?
+        [ ! -f $PIDFILE ] && return $?
         COUNTER=$(( $COUNTER - 1 ))
         sleep 0.5
     done
@@ -171,6 +171,8 @@ restart_omi()
     fi
 
     stop_omi
+    # wait omi to stop for 5 seconds
+    wait_until_omi_stops 5
     start_omi
 }
 


### PR DESCRIPTION
the timing issue on centos 6 always reproduce with below steps:
1.	install omi [Pass]
2.	restart omi service: /opt/omi/bin/service_control restart [Fail message]

Outputs:
```
~
root@ost86-ct6-02  # rpm -i omi-1.6.2-135.ssl_100.ulinux.x86.rpm
Creating omiusers group ...
Creating omi group ...
Creating omi service account ...
Restoring OMI HTTPSPORT to 0,5986 ...

************************************************************
* Warning: The certificate and keyfile were not generated  *
* since they already exist.                                *
************************************************************
2019-07-18 19:05:42 : Crontab not configured to update omi keytab automatically. Skip unconfigure
2019-07-18 19:05:42 : Crontab configured to update omi keytab automatically
Configuring OMI service ...
Trying to start omi with systemctl
Trying to start omi with initctl
Trying to start omi with /sbin/service
omi is started.
Checking if cron is installed...
Checking if cron/crond service is started...
Set up a cron job to OMI logrotate every 15 minutes
System appears to have SELinux installed, attempting to install selinux policy module for logrotate
  Trying /usr/share/selinux/packages/omi-logrotate/omi-logrotate.pp ...
  Labeling omi log files ...

~
root@ost86-ct6-02  # /opt/omi/bin/service_control restart
Trying to stop omi with systemctl
Trying to stop omi with initctl
Trying to stop omi with /sbin/service
omi is stopped.
cat: /var/opt/omi/run/omiserver.pid: No such file or directory
ERROR: List of process IDs must follow -p.
********* simple selection *********  ********* selection by list *********
-A all processes                      -C by command name
-N negate selection                   -G by real group ID (supports names)
-a all w/ tty except session leaders  -U by real user ID (supports names)
-d all except session leaders         -g by session OR by effective group name
-e all processes                      -p by process ID
T  all processes on this terminal     -s processes in the sessions given
a  all w/ tty, including other users  -t by tty
g  OBSOLETE -- DO NOT USE             -u by effective user ID (supports names)
r  only running processes             U  processes for specified users
x  processes w/o controlling ttys     t  by tty
*********** output format **********  *********** long options ***********
-o,o user-defined  -f full            --Group --User --pid --cols --ppid
-j,j job control   s  signal          --group --user --sid --rows --info
-O,O preloaded -o  v  virtual memory  --cumulative --format --deselect
-l,l long          u  user-oriented   --sort --tty --forest --version
-F   extra full    X  registers       --heading --no-heading --context
                    ********* misc options *********
-V,V  show version      L  list format codes  f  ASCII art forest
-m,m,-L,-T,H  threads   S  children in sum    -y change -l format
-M,Z  security data     c  true command name  -c scheduling class
-w,w  wide output       n  numeric WCHAN,UID  -H process hierarchy
Trying to start omi with systemctl
Trying to start omi with initctl
Trying to start omi with /sbin/service
omi is started.

~
root@ost86-ct6-02  
```