### PR TITLE
Fix is_redhat5 in Linux.data

### DIFF
--- a/Unix/installbuilder/datafiles/Linux.data
+++ b/Unix/installbuilder/datafiles/Linux.data
@@ -335,10 +335,10 @@ fi
 # return 0, means is redhat 5; 1 means others.
 is_redhat5(){
   if [ -e /usr/bin/lsb_release ];then
-        distro=`lsb_release -i | awk -F":" '{ print $2 }' | sed -e 's/^[[:space:]]*//'`
-        if [[ "${distro}" == *"RedHat"* ]]; then
-            distro_version=`lsb_release -r | awk -F":" '{ print $2 }'`
-            if [ "${distro_version}" -eq "5" ]; then
+        distro=`lsb_release -i | grep RedHat`
+        if [ ! -z "${distro}" ]; then
+            distro_version=`lsb_release -r | awk 'FS=":"{print $2}'`
+            if [ "${distro_version}" = "5" ]; then
                 return 0
             fi
         fi


### PR DESCRIPTION
@microsoft/omi-devs fixes 2 issue when check is_redhat5 in Linux.data, could you help to review this PR? thanks.
I have install private packages on all x64 platforms, and I have checked all installation logs, it works fine after the fixes, thanks.

```
root@ost64-rh6-02  # rpm -i omi-1.6.2-210.ssl_100.ulinux.x64.rpm 
Creating omiusers group ...
Creating omi group ...
Creating omi service account ...
Generating a 2048 bit RSA private key
........+++
....................+++
writing new private key to '/etc/opt/omi/ssl/omikey.pem'
-----
2019-10-23 02:31:10 : Crontab not configured to update omi keytab automatically. Skip unconfigure
2019-10-23 02:31:10 : Crontab configured to update omi keytab automatically
Checking if cron is installed...
Checking if cron/crond service is started...
Set up a cron job to OMI logrotate every 15 minutes
System appears to have SELinux installed, attempting to install selinux policy module for logrotate
  Trying /usr/share/selinux/packages/omi-selinux/omi-logrotate.pp ...
/var/tmp/rpm-tmp.cPg6eD: line 633: [:   6.0: integer expression expected
  Trying /usr/share/selinux/packages/omi-selinux/omi-selinux.pp ...
  Labeling omi log files ...
Configuring OMI service ...
Trying to start omi with systemctl
Trying to start omi with initctl
Trying to start omi with /sbin/service
omi is started.

root@ost64-un14-01  # dpkg  -i omi-1.6.2-210.ssl_100.ulinux.x64.deb
Selecting previously unselected package omi.
(Reading database ... 57121 files and directories currently installed.)
Preparing to unpack .../omi-1.6.2-210.ssl_100.ulinux.x64.deb ...
Creating omiusers group ...
Creating omi group ...
Creating omi service account ...
Unpacking omi (1.6.2.210) ...
Setting up omi (1.6.2.210) ...
Generating a 2048 bit RSA private key
.....+++
....................................................+++
writing new private key to '/etc/opt/omi/ssl/omikey.pem'
-----
2019-10-20 23:54:06 : Crontab not configured to update omi keytab automatically. Skip unconfigure
2019-10-20 23:54:06 : Crontab configured to update omi keytab automatically
Checking if cron is installed...
Checking if cron/crond service is started...
Set up a cron job to OMI logrotate every 15 minutes
System appears to have SELinux installed, attempting to install selinux policy module for logrotate
  Trying /usr/share/selinux/packages/omi-selinux/omi-logrotate.pp ...
/var/lib/dpkg/info/omi.postinst: 631: /var/lib/dpkg/info/omi.postinst: [[: not found
  Trying /usr/share/selinux/packages/omi-selinux/omi-selinux.pp ...
  Labeling omi log files ...
Configuring OMI service ...
Trying to start omi with systemctl
Trying to start omi with initctl
omi is started.
Processing triggers for ureadahead (0.100.0-16) ...
ureadahead will be reprofiled on next reboot


```