### PR TITLE
Change macos macro to avoid conflict with system defined macro

### DIFF
--- a/Unix/buildtool
+++ b/Unix/buildtool
@@ -922,7 +922,7 @@ if [ "$arg1" = "cflags" -o "$arg1" = "cxxflags" ]; then
             test -n "$errwarn_opt" && r="$r -Werror"
             r="$r -Wall"
             r="$r -I/usr/local/include"
-            r="$r -Dmacos"
+            r="$r -Dis_macos"
             r="$r -fvisibility=hidden"
             r="$r -fstack-protector-all"
             r="$r -DGSS_USE_IOV=1"

--- a/Unix/deprecated/httpclientcxx/httpclientcxx.cpp
+++ b/Unix/deprecated/httpclientcxx/httpclientcxx.cpp
@@ -693,7 +693,7 @@ Result HttpClient::Connect(
         return httpclient::FAILED;
     }
 
-#if defined(__hpux) || defined(macos) || defined(__SunOS_5_9)   // these OSs don't have sem_timedwait
+#if defined(__hpux) || defined(is_macos) || defined(__SunOS_5_9)   // these OSs don't have sem_timedwait
     // Yeah, sure, this is async.  You betcha.  That's why we're going to wait
     // here until the connect is complete.
     LOGD2((ZT("HttpClient::Connect - Beginning wait for connection complete semaphore")));
@@ -777,7 +777,7 @@ Result HttpClient::StartRequest(
     {
         httpclient::Result res;
 
-#if defined(__hpux) || defined(macos) || defined(__SunOS_5_9)   // these OSs don't have sem_timedwait
+#if defined(__hpux) || defined(is_macos) || defined(__SunOS_5_9)   // these OSs don't have sem_timedwait
         // Yeah, sure, this is async.  You betcha.  That's why we're going to wait
         // here until the send is complete.
         while (!s_notifySet)

--- a/Unix/http/httpauth.c
+++ b/Unix/http/httpauth.c
@@ -9,7 +9,7 @@
 
 #include <config.h>
 #if ( AUTHORIZATION == 1 )
-#if defined(macos)
+#if defined(is_macos)
 #include <GSS/GSS.h>
 #else
 #include <gssapi/gssapi.h>

--- a/Unix/http/httpclientauth.c
+++ b/Unix/http/httpclientauth.c
@@ -8,7 +8,7 @@
 */
 #include <config.h>
 #if AUTHORIZATION
-#if defined(macos)
+#if defined(is_macos)
 #include <GSS/GSS.h>
 #else
 #include <gssapi/gssapi.h>
@@ -38,7 +38,7 @@
 #define ENABLE_TRACING 1
 #define FORCE_TRACING  1
 
-#if GSS_USE_IOV && !defined(macos)
+#if GSS_USE_IOV && !defined(is_macos)
 #include "httpkrb5.h"
 #endif
 
@@ -229,7 +229,7 @@ typedef OM_uint32 KRB5_CALLCONV (*Gss_Wrap_Func)(OM_uint32 * minor_status,
                           const gss_buffer_t input_message_buffer,
                           int *conf_state, gss_buffer_t output_message_buffer);
 
-#if !defined(macos)
+#if !defined(is_macos)
 typedef krb5_error_code KRB5_CALLCONV
 (*krb5InitContextFn)(krb5_context *context);
 
@@ -294,7 +294,7 @@ typedef struct _Gss_Extensions
     gss_OID Gss_Krb5_Nt_Principal_Name;
     gss_OID Gss_C_Nt_User_Name;
 
-#if !defined(macos)
+#if !defined(is_macos)
     krb5InitContextFn          krb5InitContext;
     krb5ParseNameFn            krb5ParseName;
     krb5GetInitCredsPasswordFn krb5GetInitCredsPassword;
@@ -737,7 +737,7 @@ static _Success_(return == 0) int _GssClientInitLibrary( _In_ void* data, _Outpt
         _g_gssClientState.Gss_Wrap   = (Gss_Wrap_Func) fn_handle;
 
 #if GSS_USE_IOV
-#if defined(macos)
+#if defined(is_macos)
         fn_handle = dlsym(libhandle, "__ApplePrivate_gss_unwrap_iov");
         if (!fn_handle)
         {
@@ -842,7 +842,7 @@ static _Success_(return == 0) int _GssClientInitLibrary( _In_ void* data, _Outpt
             trace_HTTP_GssFunctionNotPresent("krb5_init_context");
             goto failed;
         }
-#if !defined(macos)
+#if !defined(is_macos)
         _g_gssClientState.krb5InitContext = (krb5InitContextFn)fn_handle;
 
         fn_handle = dlsym(libhandle, "krb5_parse_name");
@@ -2274,7 +2274,7 @@ HttpClient_NextAuthRequest(_In_ struct _HttpClient_SR_SocketData * self, _In_ co
 static int
 _Krb5VerifyInitCreds(const char *principalName, const char *password)
 {
-#if !defined(macos)
+#if !defined(is_macos)
     krb5_error_code ret;
     krb5_creds creds;
     krb5_principal client_princ = NULL;
@@ -2412,7 +2412,7 @@ static char *_BuildInitialGssAuthHeader(_In_ HttpClient_SR_SocketData * self, MI
             retval = _Krb5VerifyInitCreds(buffer, self->password);
             if (retval != 0 ) 
             {
-#if !defined(macos)
+#if !defined(is_macos)
                 _ReportError(self, "Kerberos verify cred with password failed", GSS_S_NO_CRED, (OM_uint32)KRB5KRB_AP_ERR_BADMATCH );
 #endif
                 return NULL;

--- a/Unix/miapi/SafeHandle.c
+++ b/Unix/miapi/SafeHandle.c
@@ -7,7 +7,7 @@
 **==============================================================================
 */
 
-#if !defined(macos)
+#if !defined(is_macos)
 #include <malloc.h>
 #endif
 #include <MI.h>

--- a/Unix/micxx/atomic.h
+++ b/Unix/micxx/atomic.h
@@ -14,7 +14,7 @@
 
 MI_BEGIN_NAMESPACE
 
-#if !defined(macos)
+#if !defined(is_macos)
 typedef struct _Atomic
 #else
 typedef struct _AtomicType

--- a/Unix/nits/base/Run.h
+++ b/Unix/nits/base/Run.h
@@ -178,7 +178,7 @@ private:
     bool m_finished;            //Stops pipe thread.
 
     int *m_statistics;
-#if !defined(macos) // Mac says this is not used
+#if !defined(is_macos) // Mac says this is not used
     int m_faultIterations;      //Cumulative fault injection iteration total.
 #endif
 

--- a/Unix/omi_error/omierror.c
+++ b/Unix/omi_error/omierror.c
@@ -332,7 +332,7 @@ MI_INLINE const MI_Char *Errno_ToString(
     _Out_writes_z_(len) MI_Char *buffer,
     MI_Uint32 len)
 {
-#if defined(macos) || ((_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600) && ! _GNU_SOURCE)
+#if defined(is_macos) || ((_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600) && ! _GNU_SOURCE)
         int ret = strerror_r(OMI_Code, buffer, len);
         if (ret != 0)
             *buffer = '\0';

--- a/Unix/pal/palcommon.h
+++ b/Unix/pal/palcommon.h
@@ -219,7 +219,7 @@ typedef PAL_Char TChar;
 **==============================================================================
 */
 
-#if defined(linux) || defined(sun) || defined(hpux) || defined(aix) || defined(macos)
+#if defined(linux) || defined(sun) || defined(hpux) || defined(aix) || defined(is_macos)
 # define PAL_HAVE_POSIX
 #endif
 
@@ -231,7 +231,7 @@ typedef PAL_Char TChar;
 **==============================================================================
 */
 
-#if defined(linux) | defined(sun) | defined(hpux) | defined(aix) | defined(macos)
+#if defined(linux) | defined(sun) | defined(hpux) | defined(aix) | defined(is_macos)
 # define PAL_HAVE_PTHREADS
 #endif
 

--- a/Unix/pal/sem.c
+++ b/Unix/pal/sem.c
@@ -12,7 +12,7 @@
 #include <pal/palcommon.h>
 #include <pal/strings.h>
 
-#if defined(macos)
+#if defined(is_macos)
 #include <semaphore.h>
 #include <uuid/uuid.h>
 #endif
@@ -35,7 +35,7 @@ _Success_(return == 0) int Sem_Init_Injected(
     unsigned int count,
     NitsCallSite cs)
 {
-#if defined(macos)
+#if defined(is_macos)
     uuid_t uniqueUUID;
     uuid_string_t uuidString;
     uuid_string_t uuidStringNoDashes;
@@ -63,7 +63,7 @@ _Success_(return == 0) int Sem_Init_Injected(
         return -1;
 # endif
 
-#if defined(macos)
+#if defined(is_macos)
 
     // The mac has a max name length of 30 characters.  Use a GUID, but truncate.  If the semaphore
     // exists, try again.

--- a/Unix/pal/sem.h
+++ b/Unix/pal/sem.h
@@ -57,7 +57,7 @@ PAL_INLINE void Sem_Destroy(
     if (self->sem)
     {
         sem_close(self->sem);
-#if !defined(macos)
+#if !defined(is_macos)
         PAL_Free(self->sem);
 #endif
         self->sem = NULL;
@@ -174,7 +174,7 @@ PAL_INLINE int NamedSem_GetValue(
     _Inout_ NamedSem* self,
     _Out_ int *value)
 {
-#if defined(macos)
+#if defined(is_macos)
     *value = 0;
     return 0;
 #else

--- a/Unix/pal/shmem.c
+++ b/Unix/pal/shmem.c
@@ -50,7 +50,7 @@ int Shmem_Open(
     }
 
 
-#if !defined(macos)
+#if !defined(is_macos)
     if (ftruncate(self->shmid, size) != 0)
     {
         close(self->shmid);

--- a/Unix/pal/thread.h
+++ b/Unix/pal/thread.h
@@ -84,7 +84,7 @@ PAL_Uint64 Thread_TID()
 {
 #if defined(CONFIG_OS_LINUX)
     return (PAL_Uint64)syscall(SYS_gettid);
-#elif defined(macos)
+#elif defined(is_macos)
     __uint64_t threadid;
     pthread_threadid_np(pthread_self(), &threadid);
     return threadid;

--- a/Unix/tests/cli/test_cli.cpp
+++ b/Unix/tests/cli/test_cli.cpp
@@ -2553,7 +2553,7 @@ NitsTestWithSetup(TestOMICLI37_GetInstanceWsmanFailKerberosAuth, TestCliSetupSud
 
         string expect = string("");
         string expected_err = string("omicli: result: MI_RESULT_ACCESS_DENIED\n");
-#if defined(macos)
+#if defined(is_macos)
         NitsCompare(InhaleTestFile("TestOMICLI37.mac.txt", expect), true, MI_T("Inhale failure"));
 #else
         NitsCompare(InhaleTestFile("TestOMICLI37.txt", expect), true, MI_T("Inhale failure"));
@@ -2628,7 +2628,7 @@ NitsTestWithSetup(TestOMICLI39_GetInstanceWsmanFailKerberosAuthSSL, TestCliSetup
 
         string expect = string("");
         string expected_err = string("omicli: result: MI_RESULT_ACCESS_DENIED\n");
-#if defined(macos)
+#if defined(is_macos)
         NitsCompare(InhaleTestFile("TestOMICLI37.mac.txt", expect), true, MI_T("Inhale failure"));
 #else
         NitsCompare(InhaleTestFile("TestOMICLI37.txt", expect), true, MI_T("Inhale failure"));
@@ -2652,7 +2652,7 @@ NitsTestWithSetup(TestOMICLI40_GetInstanceWsmanKerberosAuthWithEncrypt, TestCliS
 {
 
     /* Disabled until encrypt issues addressed */
-#if defined(macos)
+#if defined(is_macos)
     if (false)
 #else
     if (runKrbTests && startServer && !travisCI)
@@ -2710,7 +2710,7 @@ NitsTestWithSetup(TestOMICLI41_GetInstanceWsmanFailKerberosAuthWithEncrypt, Test
 
         string expect = string("");
         string expected_err = string("omicli: result: MI_RESULT_ACCESS_DENIED\n");
-#if defined(macos)
+#if defined(is_macos)
         NitsCompare(InhaleTestFile("TestOMICLI37.mac.txt", expect), true, MI_T("Inhale failure"));
 #else
         NitsCompare(InhaleTestFile("TestOMICLI37.txt", expect), true, MI_T("Inhale failure"));
@@ -2785,7 +2785,7 @@ NitsTestWithSetup(TestOMICLI45_GetInstanceWsmanFailKerberosAuthNoEncrypt, TestCl
 
         string expect = string("");
         string expected_err = string("omicli: result: MI_RESULT_ACCESS_DENIED\n");
-#if defined(macos)
+#if defined(is_macos)
         NitsCompare(InhaleTestFile("TestOMICLI37.mac.txt", expect), true, MI_T("Inhale failure"));
 #else
         NitsCompare(InhaleTestFile("TestOMICLI37.txt", expect), true, MI_T("Inhale failure"));

--- a/Unix/tests/codec/mof/blue/consts.c
+++ b/Unix/tests/codec/mof/blue/consts.c
@@ -433,7 +433,7 @@ LEX_TEST lextest[] =
             {0, 0},
         }},
 
-#if (defined(linux) && __x86_64__) || defined(macos)
+#if (defined(linux) && __x86_64__) || defined(is_macos)
     // This breaks on solaris, hpux, aix due to limitations of their strtoull
 
     {"test13", cWIntHEXMAX, sizeof(cWIntHEXMAX), {

--- a/Unix/tests/http/test_http.cpp
+++ b/Unix/tests/http/test_http.cpp
@@ -186,7 +186,7 @@ static void* MI_CALL _http_client_proc(void* param)
         r = Sock_Read(sock, r_buf, sizeof(r_buf), &read);
         err = Sock_GetLastError();
     }
-#if defined(macos)
+#if defined(is_macos)
     while (r != MI_RESULT_OK && (err == EAGAIN || err == EDEADLK));
 #else
     while (r != MI_RESULT_OK && err == EAGAIN);
@@ -738,7 +738,7 @@ static void _ConnectToServerExpectConnectionDrop(const string& data, MI_Uint32 s
             r = Sock_Read(sock, r_buf, sizeof(r_buf), &read);
             err = Sock_GetLastError();
         }
-#if defined(macos)
+#if defined(is_macos)
         while (r != MI_RESULT_OK && (err == EAGAIN || err == EDEADLK));
 #else
         while (r != MI_RESULT_OK && err == EAGAIN);

--- a/Unix/tests/http/test_httpclient.cpp
+++ b/Unix/tests/http/test_httpclient.cpp
@@ -479,7 +479,7 @@ static void* MI_CALL _http_server_proc(void* param)
         r = Sock_Read(sock, r_buf, sizeof(r_buf), &read);
         err = Sock_GetLastError();
     }
-#if defined(macos)
+#if defined(is_macos)
     while (r != MI_RESULT_OK && (err == EAGAIN || err == EDEADLK));
 #else
     while (r != MI_RESULT_OK && err == EAGAIN);

--- a/Unix/tests/wsman/test_wsmanredirect.cpp
+++ b/Unix/tests/wsman/test_wsmanredirect.cpp
@@ -108,7 +108,7 @@ static void* MI_CALL _http_server_proc(void* param)
         r = Sock_Read(sock, r_buf, sizeof(r_buf), &read);
         err = Sock_GetLastError();
     }
-#if defined(macos)
+#if defined(is_macos)
     while (r != MI_RESULT_OK && (err == EAGAIN || err == EDEADLK));
 #else
     while (r != MI_RESULT_OK && err == EAGAIN);


### PR DESCRIPTION
It seems like on recent builds of macOS (I think since 10.12) some of the system headers have defined the `macos` macro which conflicts with the `-Dmacos` macro we define when calling clang. This PR changes the `macos` macro used by omi to `is_macos` to avoid this conflict.

Before the PR running `./configure` would fail with

```
*** UNABLE TO LOCATE FILE omi.version; USING VERSION 1.0.8.6 ***
*** Update build process to include omi.version from superproject! ***
checking whether pkg-config command is on the path... yes
created /Users/jborean/dev/omi/Unix/output
checking whether C compiler is on the path... yes
checking whether C compiler compiles... yes
checking whether C program executes... yes
checking for __FUNCTION__ macro or reserved word... yes
checking for __builtin_ctz... no
checking for __builtin_prefetch... yes
checking for sched_getcpu... no
checking for wcstoll... no
checking for wcsdup... no
checking for wcscasecmp, wcsncasecmp... no
checking for vswscanf... no
checking for va_copy... no
checking for backtrace... no
checking for __sync_synchronize... yes
checking for Atomic Intrinsic Functions... no
checking for sem_timedwait... no
checking for strerror_r... yes
checking for pthread_rwlock_t... no
```

That's because it's trying to compile and run the following code

```bash
cat > /tmp/pthread_rwlock_t_func.c <<EOF
#include <pthread.h>
int main()
{
    pthread_rwlock_t lock = PTHREAD_RWLOCK_INITIALIZER;
    (void)lock;
    return 0;
}
EOF

clang -g -O2 -Wall -I/usr/local/include -Dmacos -fvisibility=hidden -fstack-protector-all -DGSS_USE_IOV=1 -o /tmp/pthread_rwlock_t_func /tmp/pthread_rwlock_t_func.c
```

This fails with multiple errors of the following

```
In file included from /tmp/pthread_rwlock_t_func.c:1:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/pthread.h:73:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/pthread/qos.h:34:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/qos.h:132:31: error: expected ','
                        __QOS_CLASS_AVAILABLE(macos(10.10), ios(8.0)) = 0x21,
                                                   ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/qos.h:126:31: note: expanded from macro
      '__QOS_CLASS_AVAILABLE'
#define __QOS_CLASS_AVAILABLE __API_AVAILABLE
```

After this change I am able to compile and build OMI on my macOS host. I'm mostly doing this so I have a `libmi.dylib` that is linked to OpenSSL 1.1 and not 1.0 that comes with PowerShell. If you wish to change the macro to another name, happy to change it to whatever you suggest.