### PR TITLE
Fix up GSSAPI auth on macOS

### DIFF
--- a/Unix/buildtool
+++ b/Unix/buildtool
@@ -923,6 +923,7 @@ if [ "$arg1" = "cflags" -o "$arg1" = "cxxflags" ]; then
             r="$r -Wall"
             r="$r -I/usr/local/include"
             r="$r -Dmacos"
+            r="$r -DHEIMDAL"
             r="$r -fvisibility=hidden"
             r="$r -fstack-protector-all"
             r="$r -DGSS_USE_IOV=1"


### PR DESCRIPTION
The current code has a few problems when running on macOS

* The `HEIMDAL` macro was not set on macOS, this causes it to try and load the wrong names.
* `GSS_C_NT_HOSTBASED_SERVICE` is not used anywhere in the code (although it probably should be)
    * Planning on revisiting this in another PR as this is the recommended name type for the target name
    * In any case the name is invalid on macOS' Heimdal implementation so just removing it was easier for now
* `GSS_KRB5_NT_PRINCIPAL_NAME` is valid for MIT krb5 but on Heimdal it needs to be accessed with `__gss_krb5_nt_principal_name_oid_desc`

Finally there was an issue when using an IP that was not routable. The `getaddrinfo()` function would set a `NULL` value for `ai_canonname`. This causes a seg fault when calling `strlen(info->ai_canonname)`. Instead this just falls back to using the HTTP hostname that was set and let it fail later on.

Ultimately this enables Kerberos auth to work on macOS.

Unfortunately enabling NTLM auth through SPNEGO requires a lot more effort that I still need to investigate. Right now the code sends the NTLM negotiate and processes the challenge message but it fails to send the authenticate message causing a failure. Hopefully it's a simple fix I can address in another PR.