### PR TITLE
Add -fcommon in buildtool to build pass in gcc10

### DIFF
--- a/Unix/buildtool
+++ b/Unix/buildtool
@@ -796,6 +796,7 @@ if [ "$arg1" = "cflags" -o "$arg1" = "cxxflags" ]; then
             test -n "$errwarn_opt" && r="$r -Werror"
             r="$r -Wall"
             r="$r -fvisibility=hidden"
+            r="$r -fcommon"
             r="$r -fno-strict-aliasing"
             r="$r -fstack-protector-all"
             r="$r -D_GNU_SOURCE"


### PR DESCRIPTION
@microsoft/omi-devs Fixes #682
With this change, we can build omi with new gcc 10, and it also doesn't affect our build system.