### PR TITLE
Enhanced security

### DIFF
--- a/Unix/base/messages.c
+++ b/Unix/base/messages.c
@@ -194,6 +194,7 @@ static const MessageField binProtocolNotificationFields[] =
     {MFT_POINTER_OPT,offsetof(BinProtocolNotification, user),0,0},
     {MFT_POINTER_OPT,offsetof(BinProtocolNotification, password),0,0},
     {MFT_POINTER_OPT,offsetof(BinProtocolNotification, authFile),0,0},
+    {MFT_POINTER_OPT,offsetof(BinProtocolNotification, message),0,0},
     {MFT_END_OF_LIST, 0, 0, 0}
 };
 
@@ -230,6 +231,12 @@ static const MessageField pamCheckUserFields[] =
 {
     {MFT_POINTER_OPT,offsetof(PamCheckUserReq, user),0,0},
     {MFT_POINTER_OPT,offsetof(PamCheckUserReq, passwd),0,0},
+    {MFT_END_OF_LIST, 0, 0, 0}
+};
+
+static const MessageField pamCheckUserRspFields[] =
+{
+    {MFT_POINTER_OPT,offsetof(PamCheckUserResp, message),0,0},
     {MFT_END_OF_LIST, 0, 0, 0}
 };
 
@@ -298,7 +305,7 @@ static const MessageDeclaration allMessages[] = {
     {postSocketFileFields,              sizeof(PostSocketFile),         MI_TRUE},
     {socketMaintenanceFields,           sizeof(VerifySocketConn),       MI_TRUE},
     {pamCheckUserFields,                sizeof(PamCheckUserReq),        MI_TRUE},
-    {emptyMessageFields,                sizeof(PamCheckUserResp),       MI_FALSE}
+    {pamCheckUserRspFields,             sizeof(PamCheckUserResp),       MI_FALSE}
 #if defined(CONFIG_ENABLE_PREEXEC)
     ,
     {execPreexecReqFields,              sizeof(ExecPreexecReq),         MI_TRUE},

--- a/Unix/base/messages.h
+++ b/Unix/base/messages.h
@@ -1191,6 +1191,7 @@ typedef struct _BinProtocolNotification
 
     /* if in nonroot mode, keeps track of which socket to send message back*/
     int             forwardSock;
+    MI_ConstString  message;
 }
 BinProtocolNotification;
 
@@ -1799,6 +1800,7 @@ typedef struct _PamCheckUserResp
     Message         base;
     MI_Uint64       handle;
     MI_Boolean      result;
+    MI_ConstString  message;
 }
 PamCheckUserResp;
 

--- a/Unix/base/oi_traces.h
+++ b/Unix/base/oi_traces.h
@@ -437,6 +437,10 @@ OI_EVENT("Username exceeds reasonable limit: %d")
 void trace_Username_Error(unsigned int bytes);
 OI_EVENT("Password exceeds reasonable limit: %d")
 void trace_Password_Error(unsigned int bytes);
+OI_EVENT("Invalid server credentials")
+void trace_InvalidServerCredentials();
+OI_EVENT("Attempt to reset secret string")
+void trace_AttemptToResetSecretString();
 
 
 
@@ -1861,6 +1865,8 @@ OI_EVENT("AgentMgr_PreExec_ResponseStrand_Close: preexecContext (%p), strand (%p
 void trace_AgentMgr_PreExec_ResponseStrand_Close(void* context, void* strand);
 OI_EVENT("AgentMgr_PreExec_ResponseStrand_Finish: preexecContext (%p), strand (%p)")
 void trace_AgentMgr_PreExec_ResponseStrand_Finish(void* context, void* strand);
+OI_EVENT("Server credentials verified (%p)")
+void trace_ServerCredentialsVerified(void* handle);
 
 /******************************** AUTH TRACES ***********************************/
 

--- a/Unix/base/oiomi.h
+++ b/Unix/base/oiomi.h
@@ -1133,6 +1133,18 @@ FILE_EVENT1(20153, trace_Password_Error_Impl, LOG_ERR, PAL_T("Password exceeds r
 #endif
 FILE_EVENT0(20154, trace_Listen_Failed_Impl, LOG_ERR, PAL_T("Listen failed on both IPv4 and IPv6"))
 #if defined(CONFIG_ENABLE_DEBUG)
+#define trace_InvalidServerCredentials() trace_InvalidServerCredentials_Impl(__FILE__, __LINE__)
+#else
+#define trace_InvalidServerCredentials() trace_InvalidServerCredentials_Impl(0, 0)
+#endif
+FILE_EVENT0(20155, trace_InvalidServerCredentials_Impl, LOG_ERR, PAL_T("Invalid Server credentials"))
+#if defined(CONFIG_ENABLE_DEBUG)
+#define trace_AttemptToResetSecretString() trace_AttemptToResetSecretString_Impl(__FILE__, __LINE__)
+#else
+#define trace_AttemptToResetSecretString() trace_AttemptToResetSecretString_Impl(0, 0)
+#endif
+FILE_EVENT0(20156, trace_AttemptToResetSecretString_Impl, LOG_ERR, PAL_T("Attempt to reset Secret String"))
+#if defined(CONFIG_ENABLE_DEBUG)
 #define trace__FindSubRequest_CannotFindKey(a0, a1, a2) trace__FindSubRequest_CannotFindKey_Impl(__FILE__, __LINE__, a0, a1, a2)
 #else
 #define trace__FindSubRequest_CannotFindKey(a0, a1, a2) trace__FindSubRequest_CannotFindKey_Impl(0, 0, a0, a1, a2)
@@ -2411,12 +2423,6 @@ FILE_EVENT2(30212, trace_TrackerHashMapAlreadyExists_Impl, LOG_WARNING, PAL_T("T
 #endif
 FILE_EVENT3(30213, trace_Selector_AddHandler_AlreadyThere_Impl, LOG_WARNING, PAL_T("Selector_AddHandler: selector=%p, handler=%p, name=%T ALREADY REGISTERED"), Selector *, Handler *, const TChar *)
 #if defined(CONFIG_ENABLE_DEBUG)
-#define trace_Selector_RemoveHandler_NotThere(a0, a1, a2) trace_Selector_RemoveHandler_NotThere_Impl(__FILE__, __LINE__, a0, a1, tcs(a2))
-#else
-#define trace_Selector_RemoveHandler_NotThere(a0, a1, a2) trace_Selector_RemoveHandler_NotThere_Impl(0, 0, a0, a1, tcs(a2))
-#endif
-FILE_EVENT3(30214, trace_Selector_RemoveHandler_NotThere_Impl, LOG_WARNING, PAL_T("Selector_RemoveHandler: selector=%p, handler=%p, name=%T NOT REGISTERED"), Selector *, Handler *, const TChar *)
-#if defined(CONFIG_ENABLE_DEBUG)
 #define trace_Stop_OMI() trace_Stop_OMI_Impl(__FILE__, __LINE__)
 #else
 #define trace_Stop_OMI() trace_Stop_OMI_Impl(0, 0)
@@ -2752,6 +2758,12 @@ FILE_EVENT0(40047, trace_Trying_IPv6_Impl, LOG_INFO, PAL_T("Trying to listen on 
 #define trace_TurnOff_IPV6_V6ONLY_Pass() trace_TurnOff_IPV6_V6ONLY_Pass_Impl(0, 0)
 #endif
 FILE_EVENT0(40048, trace_TurnOff_IPV6_V6ONLY_Pass_Impl, LOG_INFO, PAL_T("Turn off IPV6_V6ONLY pass."))
+#if defined(CONFIG_ENABLE_DEBUG)
+#define trace_Selector_RemoveHandler_NotThere(a0, a1, a2) trace_Selector_RemoveHandler_NotThere_Impl(__FILE__, __LINE__, a0, a1, tcs(a2))
+#else
+#define trace_Selector_RemoveHandler_NotThere(a0, a1, a2) trace_Selector_RemoveHandler_NotThere_Impl(0, 0, a0, a1, tcs(a2))
+#endif
+FILE_EVENT3(40049, trace_Selector_RemoveHandler_NotThere_Impl, LOG_INFO, PAL_T("Selector_RemoveHandler: selector=%p, handler=%p, name=%T NOT REGISTERED"), Selector *, Handler *, const TChar *)
 #if defined(CONFIG_ENABLE_DEBUG)
 #define trace_FunctionEntered(a0, a1) trace_FunctionEntered_Impl(__FILE__, __LINE__, scs(a0), a1)
 #else
@@ -5074,6 +5086,12 @@ FILE_EVENT2(45385, trace_AgentMgr_PreExec_ResponseStrand_Close_Impl, LOG_DEBUG, 
 #define trace_AgentMgr_PreExec_ResponseStrand_Finish(a0, a1) trace_AgentMgr_PreExec_ResponseStrand_Finish_Impl(0, 0, a0, a1)
 #endif
 FILE_EVENT2(45386, trace_AgentMgr_PreExec_ResponseStrand_Finish_Impl, LOG_DEBUG, PAL_T("AgentMgr_PreExec_ResponseStrand_Finish: preexecContext (%p), strand (%p)"), void*, void*)
+#if defined(CONFIG_ENABLE_DEBUG)
+#define trace_ServerCredentialsVerified(a0) trace_ServerCredentialsVerified_Impl(__FILE__, __LINE__, a0)
+#else
+#define trace_ServerCredentialsVerified(a0) trace_ServerCredentialsVerified_Impl(0, 0, a0)
+#endif
+FILE_EVENT1(45387, trace_ServerCredentialsVerified_Impl, LOG_DEBUG, PAL_T("Server credentials verified (%p)"), void*)
 #if defined(CONFIG_ENABLE_DEBUG)
 #define trace_HTTP_EncryptionFailed() trace_HTTP_EncryptionFailed_Impl(__FILE__, __LINE__)
 #else

--- a/Unix/http/http.c
+++ b/Unix/http/http.c
@@ -66,6 +66,8 @@ typedef void SSL_CTX;
 # define SSL3_FLAGS_NO_RENEGOTIATE_CIPHERS               0x0001
 #endif
 
+#define INVALID_ID ((uid_t)-1)
+
 int GetTimeStamp(_Pre_writable_size_(TIMESTAMP_SIZE) char buf[TIMESTAMP_SIZE]);
 
 //------------------------------------------------------------------------------
@@ -672,10 +674,13 @@ static Http_CallbackResult _ReadData(
         }
     }
 
-    r = Process_Authorized_Message(handler);
-    if (MI_RESULT_OK != r)
+    if (handler->isAuthorised)
     {
-        return PRT_RETURN_FALSE;
+        r = Process_Authorized_Message(handler);
+        if (MI_RESULT_OK != r)
+        {
+            return PRT_RETURN_FALSE;
+        }
     }
 
 Done:
@@ -1458,6 +1463,8 @@ static MI_Boolean _ListenerCallback(
         h->encryptedTransaction = FALSE;
         h->pSendAuthHeader = NULL;
         h->sendAuthHeaderLen = 0;
+        h->authInfo.uid= INVALID_ID;
+        h->authInfo.gid= INVALID_ID;
 
         h->recvBufferSize = INITIAL_BUFFER_SIZE;
         h->recvBuffer = (char*)PAL_Calloc(1, h->recvBufferSize);

--- a/Unix/protocol/protocol.h
+++ b/Unix/protocol/protocol.h
@@ -118,6 +118,7 @@ typedef struct _ProtocolSocket
 
     /* Whether socket is permanent */
     MI_Boolean permanent;
+    Handler *           engineHandler;
 }
 ProtocolSocket;
 


### PR DESCRIPTION
Introduced authentication for omiserver in omiengine for user validation and PAM based user validation.
This authentication is secret string based. This secret string can be set only once, that is duirng omiegine bootup, any other afterwards  attempt to change the secret string will be ignored.

Default user type for running any scripts will be invalid user, so that user authencication can't be skipped. Additional validation for not allowing unauthorized user to proceed.

Fixed a Use-After-Free vulnerability where omiengine's connection with client get freed before omiegnine's connection with omiserver amd resulting in Use-After-Free vulnerability. 
