### PR TITLE
Setting hdl inside AUTHORIZATION macro as it is defined inside the macro

### DIFF
--- a/Unix/http/httpauth.c
+++ b/Unix/http/httpauth.c
@@ -1629,8 +1629,7 @@ void Deauthorize(_In_ Http_SR_SocketData * handler)
              // 2do: Not clear what to do here
              // I'm going to procede anyway.
         }
-		handler->pAuthContext = hdl;
-#endif
+        handler->pAuthContext = hdl;
 #endif
     }
     if (handler->pVerifierCred)

--- a/Unix/http/httpauth.c
+++ b/Unix/http/httpauth.c
@@ -1629,8 +1629,9 @@ void Deauthorize(_In_ Http_SR_SocketData * handler)
              // 2do: Not clear what to do here
              // I'm going to procede anyway.
         }
+		handler->pAuthContext = hdl;
 #endif
-        handler->pAuthContext = hdl;
+#endif
     }
     if (handler->pVerifierCred)
     {


### PR DESCRIPTION
Setting hdl inside AUTHORIZATION macro as it is defined inside the macro

Note: If user disables AUTHORIZATION macro this code gives compilation error