### PR TITLE
Setting hdl inside AUTHORIZATION macro as it is defined inside the macro

### DIFF
--- a/Unix/http/httpauth.c
+++ b/Unix/http/httpauth.c
@@ -1629,8 +1629,8 @@ void Deauthorize(_In_ Http_SR_SocketData * handler)
              // 2do: Not clear what to do here
              // I'm going to procede anyway.
         }
-#endif
         handler->pAuthContext = hdl;
+#endif
     }
     if (handler->pVerifierCred)
     {


### PR DESCRIPTION
Disable the AUTHORIZATION macro to see this error.